### PR TITLE
fix(modal): fix modal assert methods due to change in check if elemen…

### DIFF
--- a/src/SonataAdminTrait.php
+++ b/src/SonataAdminTrait.php
@@ -130,7 +130,7 @@ trait SonataAdminTrait
         }
 
         $this->clickElement($element);
-        $this->iWaitForCssElementBeingVisible('body > .modal .modal-title', 5);
+        $this->iWaitForCssElementBeingVisible('.modal', 5);
     }
 
     /**
@@ -147,13 +147,8 @@ trait SonataAdminTrait
             throw new \RuntimeException(sprintf('Please use the trait %s in the class %s', ExtraSessionTrait::class, __CLASS__));
         }
 
-        $invisible = $this->iWaitForCssElementBeingInvisible('body > .modal > .modal-dialog', 5);
-
-        if (!$invisible) {
-            $element = $this->getSession()->getPage()->find('css', 'body > .modal > .modal-dialog');
-
-            throw new ElementHtmlException('Popin .modal-dialog was found and opened', $this->getSession()->getDriver(), $element);
-        }
+        $this->iWaitForCssElementBeingInvisible('.modal', 5);
+        $this->thePopinShouldNotBeOpened();
     }
 
     /**
@@ -165,10 +160,10 @@ trait SonataAdminTrait
      */
     public function thePopinShouldNotBeOpened()
     {
-        $element = $this->getSession()->getPage()->find('css', 'body > .modal > .modal-dialog');
+        $element = $this->getSession()->getPage()->find('css', '.modal');
 
         if ($element && $element->isVisible()) {
-            throw new ElementHtmlException('Popin .modal-dialog was found and opened', $this->getSession()->getDriver(), $element);
+            throw new ElementHtmlException('Popin .modal was found and opened', $this->getSession()->getDriver(), $element);
         }
     }
 
@@ -181,10 +176,10 @@ trait SonataAdminTrait
      */
     public function thePopinShouldBeOpened()
     {
-        $element = $this->getSession()->getPage()->find('css', 'body > .modal > .modal-dialog');
+        $element = $this->getSession()->getPage()->find('css', '.modal');
 
         if (!$element || !$element->isVisible()) {
-            throw new ElementNotVisible('Modal .modal-dialog should be opened and visible');
+            throw new ElementNotVisible('Modal .modal should be opened and visible');
         }
     }
 

--- a/tests/SonataAdminTraitTest.php
+++ b/tests/SonataAdminTraitTest.php
@@ -209,7 +209,7 @@ class SonataAdminTraitTest extends TestCase
      * Tests the thePopinShouldNotBeOpened method with element found and visible.
      *
      * @expectedException Behat\Mink\Exception\ElementHtmlException
-     * @expectedExceptionMessage Popin .modal-dialog was found and opened
+     * @expectedExceptionMessage Popin .modal was found and opened
      */
     public function testThePopinShouldNotBeOpenedWithOpenedPopin()
     {
@@ -220,7 +220,7 @@ class SonataAdminTraitTest extends TestCase
         $mock    = $this->getSonataAdminMock();
 
         $element->expects($this->once())->method('isVisible')->willReturn(true);
-        $page->expects($this->once())->method('find')->with($this->equalTo('css'), $this->equalTo('body > .modal > .modal-dialog'))->willReturn($element);
+        $page->expects($this->once())->method('find')->with($this->equalTo('css'), $this->equalTo('.modal'))->willReturn($element);
         $session->expects($this->once())->method('getPage')->willReturn($page);
         $session->expects($this->once())->method('getDriver')->willReturn($driver);
         $mock->expects($this->exactly(2))->method('getSession')->willReturn($session);
@@ -237,7 +237,7 @@ class SonataAdminTraitTest extends TestCase
         $page    = $this->createMock(DocumentElement::class);
         $mock    = $this->getSonataAdminMock();
 
-        $page->expects($this->once())->method('find')->with($this->equalTo('css'), $this->equalTo('body > .modal > .modal-dialog'))->willReturn(null);
+        $page->expects($this->once())->method('find')->with($this->equalTo('css'), $this->equalTo('.modal'))->willReturn(null);
         $session->expects($this->once())->method('getPage')->willReturn($page);
         $mock->expects($this->once())->method('getSession')->willReturn($session);
 
@@ -255,7 +255,7 @@ class SonataAdminTraitTest extends TestCase
         $mock    = $this->getSonataAdminMock();
 
         $element->expects($this->once())->method('isVisible')->willReturn(true);
-        $page->expects($this->once())->method('find')->with($this->equalTo('css'), $this->equalTo('body > .modal > .modal-dialog'))->willReturn($element);
+        $page->expects($this->once())->method('find')->with($this->equalTo('css'), $this->equalTo('.modal'))->willReturn($element);
         $session->expects($this->once())->method('getPage')->willReturn($page);
         $mock->expects($this->once())->method('getSession')->willReturn($session);
 
@@ -266,7 +266,7 @@ class SonataAdminTraitTest extends TestCase
      * Tests the thePopinShouldBeOpened method with element found and invisible.
      *
      * @expectedException WebDriver\Exception\ElementNotVisible
-     * @expectedExceptionMessage Modal .modal-dialog should be opened and visible
+     * @expectedExceptionMessage Modal .modal should be opened and visible
      */
     public function testThePopinShouldBeOpenedWithInvisiblePopin()
     {
@@ -276,7 +276,7 @@ class SonataAdminTraitTest extends TestCase
         $mock    = $this->getSonataAdminMock();
 
         $element->expects($this->once())->method('isVisible')->willReturn(false);
-        $page->expects($this->once())->method('find')->with($this->equalTo('css'), $this->equalTo('body > .modal > .modal-dialog'))->willReturn($element);
+        $page->expects($this->once())->method('find')->with($this->equalTo('css'), $this->equalTo('.modal'))->willReturn($element);
         $session->expects($this->once())->method('getPage')->willReturn($page);
         $mock->expects($this->once())->method('getSession')->willReturn($session);
 
@@ -287,7 +287,7 @@ class SonataAdminTraitTest extends TestCase
      * Tests the thePopinShouldBeOpened method without element found.
      *
      * @expectedException WebDriver\Exception\ElementNotVisible
-     * @expectedExceptionMessage Modal .modal-dialog should be opened and visible
+     * @expectedExceptionMessage Modal .modal should be opened and visible
      */
     public function testThePopinShouldBeOpenedWithoutPopin()
     {
@@ -295,7 +295,7 @@ class SonataAdminTraitTest extends TestCase
         $page    = $this->createMock(DocumentElement::class);
         $mock    = $this->getSonataAdminMock();
 
-        $page->expects($this->once())->method('find')->with($this->equalTo('css'), $this->equalTo('body > .modal > .modal-dialog'))->willReturn(null);
+        $page->expects($this->once())->method('find')->with($this->equalTo('css'), $this->equalTo('.modal'))->willReturn(null);
         $session->expects($this->once())->method('getPage')->willReturn($page);
         $mock->expects($this->once())->method('getSession')->willReturn($session);
 


### PR DESCRIPTION
…t is visible or not

Due to change previous changes on iWaitForCssElementBeingVisible & iWaitForCssElementBeingInvisible. The display attribute is owned by .modal element