### PR TITLE
feat(sonataPageAdminTrait): add behat helpers for sonata-page bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 master
 ------
 
-* todo
+* Add helpers for sonata-project/page-bundle
 
 v0.1.1
 ------

--- a/README.md
+++ b/README.md
@@ -339,6 +339,58 @@ Scenario: I can login and then access to the admin dashboard
     And I should see "Welcome to the admin dashboard"
 ```
 
+### SonataPageAdminTrait
+
+This trait integrates [sonata-project/page-bundle][4] with some basics like interaction with container, block...
+You can combined it with the [ReloadCookiesTrait](#reloadcookiestrait) and with [RouterAwareTrait](#routerawaretrait) to use route ids.
+
+```php
+// your feature context
+
+namespace Tests\Behat\Context;
+
+use Behat\MinkExtension\Context\MinkContext;
+use Behat\Symfony2Extension\Context\KernelDictionary;
+use Ekino\BehatHelpers\SonataPageAdminTrait;
+
+class MyFeatureContext extends MinkContext
+{
+    use KernelDictionary;
+    use ReloadCookiesTrait;
+    use RouterAwareTrait;
+    use SonataPageAdminTrait;
+}
+```
+
+```gherkin
+Scenario: I can see "Simple text block" when I add a SimpleTextBlockService
+Given     I login
+Then      I am on "admin_app_sonata_page_compose;id=1"
+And       I open the container by text "Content"
+And       I add the block "Simple text" with the name "Foo"
+And       I open the block "Foo"
+And       The block "Foo" should be opened
+And       I rename the block "Foo" with "Bar"
+And       I submit the block "Foo"
+And       The block "Bar" should be closed
+And       I should see 1 blocks
+And       I delete the block "Bar"
+```
+
+| Step | Regex |
+| --- | --- |
+| I open the container by text "Content" | `/^I open the container "([^"]*)"$/` |
+| I add the block "Simple text" with the name "Foo" | `/^I add the block "([^"]*)" with the name "([^"]*)"$/` |
+| I go to the tab "English" of the block "Foo" | `/^I go to the tab "([^"]*)" of the block "([^"]*)"$/` |
+| I should see 6 blocks | `/^I should see (\d+) blocks$/` |
+| I open the block "Foo" | `/^I open the block "([^"]*)"$/` |
+| I submit the block "Foo" | `/^I submit the block "([^"]*)"$/` |
+| I delete the block "Foo" | `/^I delete the block "([^"]*)"$/` |
+| I rename the block "Foo" with "Bar" | `/^I rename the block "([^"]*)" with "([^"]*)"$/` |
+| The block "Foo" should be opened | `/^The block "([^"]*)" should be opened$/` |
+| The block "Foo" should be closed | `/^The block "([^"]*)" should be closed$/` |
+
 [1]: https://github.com/Behat/Symfony2Extension
 [2]: https://github.com/doctrine/DoctrineBundle
 [3]: https://github.com/sonata-project/SonataAdminBundle
+[4]: https://github.com/sonata-project/SonataPageBundle

--- a/src/ExtraWebAssertTrait.php
+++ b/src/ExtraWebAssertTrait.php
@@ -35,6 +35,20 @@ trait ExtraWebAssertTrait
     }
 
     /**
+     * Checks that an attribute of a specific element does not contain text.
+     *
+     * @Then /^the attribute "(?P<attribute>(?:[^"]|\\")*)" of "(?P<element>[^"]*)" element should not have value "(?P<value>(?:[^"]|\\")*)"$/
+     *
+     * @param string $element
+     * @param string $attribute
+     * @param string $value
+     */
+    public function elementAttributeNotContains(string $element, string $attribute, string $value): void
+    {
+        $this->assertSession()->elementAttributeNotContains('css', $element, $attribute, $value);
+    }
+
+    /**
      * @When /^I click the "(?P<element>[^"]*)" element$/
      *
      * @param string $element

--- a/src/SonataPageAdminTrait.php
+++ b/src/SonataPageAdminTrait.php
@@ -1,0 +1,303 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the behat/helpers project.
+ *
+ * (c) Ekino
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ekino\BehatHelpers;
+
+use Behat\Mink\Exception\ElementNotFoundException;
+
+/**
+ * @author William JEHANNE <william.jehanne@ekino.com>
+ */
+trait SonataPageAdminTrait
+{
+    /**
+     * I open the container by text.
+     *
+     * @When /^I open the container by text "([^"]*)"$/
+     *
+     * @param string $text
+     *
+     * @throws ElementNotFoundException
+     */
+    public function iOpenTheContainerByText(string $text): void
+    {
+        $element = $this->getSession()->getPage()->find('css', sprintf('div.page-composer__page-preview a:contains(\'%s\')', $text));
+
+        if (null === $element) {
+            throw new ElementNotFoundException($this->getSession()->getDriver(), null, 'text', $text);
+        }
+
+        $element->click();
+    }
+
+    /**
+     * I add a block with the name.
+     *
+     * @When /^I add the block "([^"]*)" with the name "([^"]*)"$/
+     *
+     * @param string $text
+     * @param string $name
+     *
+     * @throws ElementNotFoundException
+     */
+    public function iAddABlockWithTheName(string $text, string $name): void
+    {
+        $buttonElement = 'div.page-composer__block-type-selector button';
+        $inputElement  = sprintf('li.page-composer__container__child:contains(\'%s\') * input.page-composer__container__child__name__input', $text);
+        $blockElement  = sprintf('a.BlockSelectModal_SelectLink:contains(\'%s\')', $text);
+
+        $this->iWaitForCssElementBeingVisible($buttonElement, 2);
+        $this->clickingOnElementShouldOpenPopin($buttonElement, 'blockSelectModal');
+
+        $this->iWaitForCssElementBeingVisible($blockElement, 2);
+
+        $block = $this->getSession()->getPage()->find('css', $blockElement);
+
+        if (null === $block) {
+            throw new ElementNotFoundException($this->getSession()->getDriver(), null, 'block', $text);
+        }
+
+        $block->click();
+        $this->thePopinShouldBeClosed('blockSelectModal');
+        $this->iWaitForCssElementBeingVisible($inputElement, 2);
+
+        $input = $this->getSession()->getPage()->find('css', $inputElement);
+
+        if (null === $input) {
+            throw new ElementNotFoundException($this->getSession()->getDriver(), null, 'input', $text);
+        }
+
+        $input->setValue($name);
+    }
+
+    /**
+     * I go to the tab of the block.
+     *
+     * @When /^I go to the tab "([^"]*)" of the block "([^"]*)"$/
+     *
+     * @param string $tab
+     * @param string $block
+     *
+     * @throws ElementNotFoundException
+     */
+    public function iGoToTheTabOfTheBlock(string $tab, string $block): void
+    {
+        $tab = $this->getSession()->getPage()->find('css', sprintf('li.page-composer__container__child:contains(\'%s\') * a:contains(\'%s\')', $block, $tab));
+
+        if (null === $tab) {
+            throw new ElementNotFoundException($this->getSession()->getDriver(), null, 'tab', $tab);
+        }
+
+        $tab->click();
+    }
+
+    /**
+     * I should see n blocks.
+     *
+     * @When /^I should see (\d+) blocks$/
+     *
+     * @param int $num
+     *
+     * @throws ElementNotFoundException
+     */
+    public function iShouldSeeBlocks(int $num): void
+    {
+        $selector = 'div.page-composer__container__view > ul.page-composer__container__children > li';
+
+        $element = $this->getSession()->getPage()->find('css', $selector);
+
+        if (null === $element) {
+            throw new ElementNotFoundException($this->getSession()->getDriver(), null, 'elements', $element);
+        }
+
+        $this->assertNumElements($num, $selector);
+    }
+
+    /**
+     * I open the block.
+     *
+     * @When /^I open the block "([^"]*)"$/
+     *
+     * @param string $name
+     *
+     * @throws ElementNotFoundException
+     */
+    public function iOpenTheBlock(string $name): void
+    {
+        $element = sprintf('li.page-composer__container__child:contains(\'%s\') > a.page-composer__container__child__edit', $name);
+
+        $this->iWaitForCssElementBeingVisible($element, 2);
+
+        $block = $this->getSession()->getPage()->find('css', $element);
+
+        if (null === $block) {
+            throw new ElementNotFoundException($this->getSession()->getDriver(), null, 'block', $block);
+        }
+
+        $block->click();
+    }
+
+    /**
+     * I submit the block.
+     *
+     * @When /^I submit the block "([^"]*)"$/
+     *
+     * @param string $name
+     *
+     * @throws ElementNotFoundException
+     */
+    public function iSubmitTheBlock(string $name): void
+    {
+        $button = $this->getSession()->getPage()->find('css', sprintf('li.page-composer__container__child:contains(\'%s\') * button[type=submit]', $name));
+
+        if (null === $button) {
+            throw new ElementNotFoundException($this->getSession()->getDriver(), null, 'block', $button);
+        }
+
+        $button->press();
+    }
+
+    /**
+     * I delete the block.
+     *
+     * @When /^I delete the block "([^"]*)"$/
+     *
+     * @param string $name
+     *
+     * @throws ElementNotFoundException
+     */
+    public function iDeleteTheBlock(string $name): void
+    {
+        $block = $this->getSession()->getPage()->find('css', sprintf('li:contains(\'%s\')', $name));
+
+        if (null === $block) {
+            throw new ElementNotFoundException($this->getSession()->getDriver(), null, 'block', $block);
+        }
+
+        $id = $block->getAttribute('data-block-id');
+
+        $this->iOpenTheBlock($name);
+
+        $buttonElement = sprintf('li.page-composer__container__child[data-block-id=%d] * a.btn-danger', $id);
+        $this->iWaitForCssElementBeingVisible($buttonElement, 1);
+        $button        = $this->getSession()->getPage()->find('css', $buttonElement);
+
+        if (null === $button) {
+            throw new ElementNotFoundException($this->getSession()->getDriver(), null, 'button', $button);
+        }
+
+        $this->getSession()->executeScript(sprintf('window.scrollTo($(\'%s\').position().top+200, $(\'%s\').position().left+200);', $buttonElement, $buttonElement));
+
+        $button->press();
+
+        $btnDanger = 'button.btn-danger';
+
+        $this->iWaitForCssElementBeingVisible($btnDanger, 1);
+
+        $button = $this->getSession()->getPage()->find('css', $btnDanger);
+
+        if (null === $button) {
+            throw new ElementNotFoundException($this->getSession()->getDriver(), null, 'button', $button);
+        }
+
+        $button->click();
+    }
+
+    /**
+     * I rename the block with.
+     *
+     * @When  /^I rename the block "([^"]*)" with "([^"]*)"$/
+     *
+     * @param string $oldName
+     * @param string $newName
+     *
+     * @throws ElementNotFoundException
+     */
+    public function iRenameTheBlock(string $oldName, string $newName): void
+    {
+        $this->iOpenTheBlock($oldName);
+
+        $block = $this->getSession()->getPage()->find('css', sprintf('li:contains(\'%s\')', $oldName));
+
+        if (null === $block) {
+            throw new ElementNotFoundException($this->getSession()->getDriver(), null, 'block', $block);
+        }
+
+        $id      = $block->getAttribute('data-block-id');
+        $element = sprintf('li[data-block-id=%d] * input.page-composer__container__child__name__input', $id);
+
+        $this->iWaitForCssElementBeingVisible($element, 2);
+
+        $input = $this->getSession()->getPage()->find('css', $element);
+
+        if (null === $input) {
+            throw new ElementNotFoundException($this->getSession()->getDriver(), null, 'input', $block);
+        }
+
+        $input->setValue($newName);
+
+        $button = $this->getSession()->getPage()->find('css', sprintf('li[data-block-id=%d] * button[type=submit]', $id));
+
+        if (null === $button) {
+            throw new ElementNotFoundException($this->getSession()->getDriver(), null, 'block', $button);
+        }
+
+        $button->press();
+    }
+
+    /**
+     * The block should be opened.
+     *
+     * @When /^The block "([^"]*)" should be opened$/
+     *
+     * @param string $name
+     *
+     * @throws ElementNotFoundException
+     */
+    public function theBlockShouldBeOpened(string $name): void
+    {
+        $block = $this->getSession()->getPage()->find('css', sprintf('li:contains(\'%s\')', $name));
+
+        if (null === $block) {
+            throw new ElementNotFoundException($this->getSession()->getDriver(), null, 'block', $block);
+        }
+
+        $id      = $block->getAttribute('data-block-id');
+        $element = sprintf('li.page-composer__container__child[data-block-id=%d] > div.page-composer__container__child__content', $id);
+
+        $this->assertSession()->elementContains('css', $element, 'form');
+    }
+
+    /**
+     * The block should be closed.
+     *
+     * @When /^The block "([^"]*)" should be closed$/
+     *
+     * @param string $name
+     *
+     * @throws ElementNotFoundException
+     */
+    public function theBlockShouldBeClosed(string $name): void
+    {
+        $element = sprintf('li.page-composer__container__child:contains(\'%s\')', $name);
+        $block   = $this->getSession()->getPage()->find('css', $element);
+
+        $this->iWaitForCssElementBeingVisible($element, 2);
+
+        if (null === $block) {
+            throw new ElementNotFoundException($this->getSession()->getDriver(), null, 'block', $block);
+        }
+
+        $this->elementAttributeNotContains($element, 'class', 'page-composer__container__child--expanded');
+    }
+}

--- a/tests/ExtraWebAssertTraitTest.php
+++ b/tests/ExtraWebAssertTraitTest.php
@@ -16,6 +16,7 @@ namespace Tests\Ekino\BehatHelpers;
 use Behat\Mink\Driver\DriverInterface;
 use Behat\Mink\Element\DocumentElement;
 use Behat\Mink\Element\NodeElement;
+use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\Mink\Session;
 use Behat\Mink\WebAssert;
 use Ekino\BehatHelpers\ExtraWebAssertTrait;
@@ -45,8 +46,6 @@ class ExtraWebAssertTraitTest extends TestCase
 
     /**
      * Asserts the method clickElement throws an exception if element not found.
-     *
-     * @expectedException \Behat\Mink\Exception\ElementNotFoundException
      */
     public function testClickElementThrowsExceptionIfElementNotFound(): void
     {
@@ -60,6 +59,8 @@ class ExtraWebAssertTraitTest extends TestCase
         /** @var ExtraWebAssertTrait|MockObject $mock */
         $mock = $this->getExtraWebAssertMock();
         $mock->expects($this->exactly(2))->method('getSession')->willReturn($session);
+
+        $this->expectException(ElementNotFoundException::class);
 
         $mock->clickElement('.sonata-ba-list a.sonata-link-identifier');
     }
@@ -127,9 +128,6 @@ class ExtraWebAssertTraitTest extends TestCase
 
     /**
      * Tests the assertAtLeastNumElements method.
-     *
-     * @expectedException \Exception
-     * @expectedExceptionMessage 1 ".foo" found on the page, but should at least 2.
      */
     public function testAssertAtLeastNumElementsNotEnough(): void
     {
@@ -145,14 +143,14 @@ class ExtraWebAssertTraitTest extends TestCase
         $mock = $this->getExtraWebAssertMock();
         $mock->expects($this->once())->method('getSession')->willReturn($session);
 
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("1 \".foo\" found on the page, but should at least 2.");
+
         $mock->assertAtLeastNumElements(2, '.foo');
     }
 
     /**
      * Tests the assertElementVisible method.
-     *
-     * @expectedException \Exception
-     * @expectedExceptionMessage Element matching css ".foo" not found.
      */
     public function testAssertAtLeastNumElementsThrowsExceptionIfElementNotFound(): void
     {
@@ -166,6 +164,9 @@ class ExtraWebAssertTraitTest extends TestCase
         /** @var ExtraWebAssertTrait|MockObject $mock */
         $mock = $this->getExtraWebAssertMock();
         $mock->expects($this->exactly(2))->method('getSession')->willReturn($session);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("Element matching css \".foo\" not found.");
 
         $mock->assertAtLeastNumElements(2, '.foo');
     }
@@ -192,9 +193,6 @@ class ExtraWebAssertTraitTest extends TestCase
 
     /**
      * Tests the assertExactlyNumElement method.
-     *
-     * @expectedException \Exception
-     * @expectedExceptionMessage 1 ".foo" found on the page, but should find 2.
      */
     public function testAssertExactlyNumElementNotEnough(): void
     {
@@ -210,14 +208,14 @@ class ExtraWebAssertTraitTest extends TestCase
         $mock = $this->getExtraWebAssertMock();
         $mock->expects($this->once())->method('getSession')->willReturn($session);
 
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("1 \".foo\" found on the page, but should find 2.");
+
         $mock->assertExactlyNumElement(2, '.foo');
     }
 
     /**
      * Tests the assertExactlyNumElement method.
-     *
-     * @expectedException \Exception
-     * @expectedExceptionMessage 3 ".foo" found on the page, but should find 2.
      */
     public function testAssertExactlyNumElementTooMuch(): void
     {
@@ -233,14 +231,14 @@ class ExtraWebAssertTraitTest extends TestCase
         $mock = $this->getExtraWebAssertMock();
         $mock->expects($this->once())->method('getSession')->willReturn($session);
 
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("3 \".foo\" found on the page, but should find 2.");
+
         $mock->assertExactlyNumElement(2, '.foo');
     }
 
     /**
      * Tests the assertExactlyNumElement method.
-     *
-     * @expectedException \Exception
-     * @expectedExceptionMessage Element matching css ".foo" not found.
      */
     public function testAssertExactlyNumElementThrowsExceptionIfElementNotFound(): void
     {
@@ -255,7 +253,25 @@ class ExtraWebAssertTraitTest extends TestCase
         $mock = $this->getExtraWebAssertMock();
         $mock->expects($this->exactly(2))->method('getSession')->willReturn($session);
 
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("Element matching css \".foo\" not found.");
+
         $mock->assertExactlyNumElement(2, '.foo');
+    }
+
+    /**
+     * Tests the elementAttributeNotContains method.
+     */
+    public function testElementAttributeNotContains(): void
+    {
+        $webAssert = $this->createMock(WebAssert::class);
+        $webAssert->expects($this->once())->method('elementAttributeNotContains')->with($this->equalTo('css'), $this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo('value'));
+
+        /** @var ExtraWebAssertTrait|MockObject $mock */
+        $mock = $this->getExtraWebAssertMock();
+        $mock->expects($this->once())->method('assertSession')->willReturn($webAssert);
+
+        $mock->elementAttributeNotContains('foo', 'bar', 'value');
     }
 
     /**

--- a/tests/SonataAdminTraitTest.php
+++ b/tests/SonataAdminTraitTest.php
@@ -16,10 +16,13 @@ namespace Tests\Ekino\BehatHelpers;
 use Behat\Mink\Driver\DriverInterface;
 use Behat\Mink\Element\DocumentElement;
 use Behat\Mink\Element\NodeElement;
+use Behat\Mink\Exception\ElementHtmlException;
+use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\Mink\Session;
 use Ekino\BehatHelpers\SonataAdminTrait;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use WebDriver\Exception\ElementNotVisible;
 
 /**
  * @author Rémi Marseille <remi.marseille@ekino.com>
@@ -64,9 +67,6 @@ class SonataAdminTraitTest extends TestCase
 
     /**
      * Tests the iOpenMenuItemByText method with no element found.
-     *
-     * @expectedException Behat\Mink\Exception\ElementNotFoundException
-     * @expectedExceptionMessage Tag with text "foo" not found
      */
     public function testIOpenMenuItemByTextWithElementNotFound(): void
     {
@@ -81,14 +81,14 @@ class SonataAdminTraitTest extends TestCase
         $session->expects($this->once())->method('getDriver')->willReturn($driver);
         $mock->expects($this->exactly(2))->method('getSession')->willReturn($session);
 
+        $this->expectException(ElementNotFoundException::class);
+        $this->expectExceptionMessage("Tag with text \"foo\" not found");
+
         $mock->iOpenMenuItemByText('foo');
     }
 
     /**
      * Tests the iShouldSeeActionInNavbar method with element not found.
-     *
-     * @expectedException Behat\Mink\Exception\ElementNotFoundException
-     * @expectedExceptionMessage Tag with text "foo" not found
      */
     public function testIShouldSeeActionInNavbarWithoutElementFound(): void
     {
@@ -103,14 +103,14 @@ class SonataAdminTraitTest extends TestCase
         $session->expects($this->once())->method('getPage')->willReturn($page);
         $mock->expects($this->exactly(2))->method('getSession')->willReturn($session);
 
+        $this->expectException(ElementNotFoundException::class);
+        $this->expectExceptionMessage("Tag with text \"foo\" not found");
+
         $mock->iShouldSeeActionInNavbar('foo');
     }
 
     /**
      * Tests the iShouldSeeActionInNavbar method with element not visible.
-     *
-     * @expectedException WebDriver\Exception\ElementNotVisible
-     * @expectedExceptionMessage Cannot find action "foo" in Navbar action
      */
     public function testIShouldSeeActionInNavbarWithoutElementNotVisible(): void
     {
@@ -125,14 +125,14 @@ class SonataAdminTraitTest extends TestCase
         $session->expects($this->once())->method('getPage')->willReturn($page);
         $mock->expects($this->once())->method('getSession')->willReturn($session);
 
+        $this->expectException(ElementNotVisible::class);
+        $this->expectExceptionMessage("Cannot find action \"foo\" in Navbar action");
+
         $mock->iShouldSeeActionInNavbar('foo');
     }
 
     /**
      * Tests the iShouldNotSeeActionInNavbar method with element.
-     *
-     * @expectedException Behat\Mink\Exception\ElementHtmlException
-     * @expectedExceptionMessage Action "foo" has been found in Navbar action
      */
     public function testIShouldNotSeeActionInNavbarWithElement(): void
     {
@@ -148,14 +148,14 @@ class SonataAdminTraitTest extends TestCase
         $session->expects($this->once())->method('getPage')->willReturn($page);
         $mock->expects($this->exactly(2))->method('getSession')->willReturn($session);
 
+        $this->expectException(ElementHtmlException::class);
+        $this->expectExceptionMessage("Action \"foo\" has been found in Navbar action");
+
         $mock->iShouldNotSeeActionInNavbar('foo');
     }
 
     /**
      * Tests the iClickOnActionInNavbar method with element not found.
-     *
-     * @expectedException Behat\Mink\Exception\ElementNotFoundException
-     * @expectedExceptionMessage Tag with text "foo" not found
      */
     public function testIClickOnActionInNavbarWithoutElementFound(): void
     {
@@ -169,6 +169,9 @@ class SonataAdminTraitTest extends TestCase
         $session->expects($this->once())->method('getDriver')->willReturn($driver);
         $session->expects($this->once())->method('getPage')->willReturn($page);
         $mock->expects($this->exactly(2))->method('getSession')->willReturn($session);
+
+        $this->expectException(ElementNotFoundException::class);
+        $this->expectExceptionMessage("Tag with text \"foo\" not found");
 
         $mock->iClickOnActionInNavbar('foo');
     }
@@ -194,35 +197,34 @@ class SonataAdminTraitTest extends TestCase
 
     /**
      * Tests the clickingOnElementShouldOpenPopin method.
-     *
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Please use the trait Ekino\BehatHelpers\ExtraSessionTrait in the class Trait_SonataAdminTrait
      */
     public function testClickingOnElementShouldOpenPopinWithoutExtraSessionTraitUse(): void
     {
         /** @var SonataAdminTrait|MockObject $mock */
         $mock = $this->getSonataAdminMock();
+
+        $this->expectExceptionMessage("Please use the trait Ekino\BehatHelpers\ExtraSessionTrait in the class Trait_SonataAdminTrait");
+        $this->expectException(\RuntimeException::class);
+
         $mock->clickingOnElementShouldOpenPopin('foo', 'bar');
     }
 
     /**
      * Tests the thePopinShouldBeClosed method.
-     *
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Please use the trait Ekino\BehatHelpers\ExtraSessionTrait in the class Trait_SonataAdminTrait
      */
     public function testThePopinShouldBeClosedWithoutExtraSessionTraitUse(): void
     {
         /** @var SonataAdminTrait|MockObject $mock */
         $mock = $this->getSonataAdminMock();
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage("Please use the trait Ekino\BehatHelpers\ExtraSessionTrait in the class Trait_SonataAdminTrait");
+
         $mock->clickingOnElementShouldOpenPopin('foo', 'bar');
     }
 
     /**
      * Tests the thePopinShouldNotBeOpened method with element found and visible.
-     *
-     * @expectedException Behat\Mink\Exception\ElementHtmlException
-     * @expectedExceptionMessage Popin div.modal[id$=foo] was found and opened
      */
     public function testThePopinShouldNotBeOpenedWithOpenedPopin(): void
     {
@@ -238,6 +240,9 @@ class SonataAdminTraitTest extends TestCase
         $session->expects($this->once())->method('getPage')->willReturn($page);
         $session->expects($this->once())->method('getDriver')->willReturn($driver);
         $mock->expects($this->exactly(2))->method('getSession')->willReturn($session);
+
+        $this->expectExceptionMessage("Popin div.modal[id$=foo] was found and opened");
+        $this->expectException(ElementHtmlException::class);
 
         $mock->thePopinShouldNotBeOpened('foo');
     }
@@ -280,9 +285,6 @@ class SonataAdminTraitTest extends TestCase
 
     /**
      * Tests the thePopinShouldBeOpened method with element found and invisible.
-     *
-     * @expectedException WebDriver\Exception\ElementNotVisible
-     * @expectedExceptionMessage Modal div.modal[id$=foo] should be opened and visible
      */
     public function testThePopinShouldBeOpenedWithInvisiblePopin(): void
     {
@@ -297,14 +299,14 @@ class SonataAdminTraitTest extends TestCase
         $session->expects($this->once())->method('getPage')->willReturn($page);
         $mock->expects($this->once())->method('getSession')->willReturn($session);
 
+        $this->expectExceptionMessage("Modal div.modal[id$=foo] should be opened and visible");
+        $this->expectException(ElementNotVisible::class);
+
         $mock->thePopinShouldBeOpened('foo');
     }
 
     /**
      * Tests the thePopinShouldBeOpened method without element found.
-     *
-     * @expectedException WebDriver\Exception\ElementNotVisible
-     * @expectedExceptionMessage Modal div.modal[id$=foo] should be opened and visible
      */
     public function testThePopinShouldBeOpenedWithoutPopin(): void
     {
@@ -316,6 +318,9 @@ class SonataAdminTraitTest extends TestCase
         $page->expects($this->once())->method('find')->with($this->equalTo('css'), $this->equalTo('div.modal[id$=foo]'))->willReturn(null);
         $session->expects($this->once())->method('getPage')->willReturn($page);
         $mock->expects($this->once())->method('getSession')->willReturn($session);
+
+        $this->expectExceptionMessage("Modal div.modal[id$=foo] should be opened and visible");
+        $this->expectException(ElementNotVisible::class);
 
         $mock->thePopinShouldBeOpened('foo');
     }

--- a/tests/SonataPageAdminTraitTest.php
+++ b/tests/SonataPageAdminTraitTest.php
@@ -1,0 +1,728 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the behat/helpers project.
+ *
+ * (c) Ekino
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Ekino\BehatHelpers;
+
+use Behat\Mink\Driver\DriverInterface;
+use Behat\Mink\Element\DocumentElement;
+use Behat\Mink\Element\NodeElement;
+use Behat\Mink\Exception\ElementNotFoundException;
+use Behat\Mink\Session;
+use Behat\Mink\WebAssert;
+use Ekino\BehatHelpers\SonataPageAdminTrait;
+use phpmock\Mock;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Twig\Node\EmbedNode;
+
+/**
+ * @author William JEHANNE <william.jehanne@ekino.com>
+ */
+class SonataPageAdminTraitTest extends TestCase
+{
+    /**
+     * @var Session|MockObject
+     */
+    private $session;
+
+    /**
+     * @var DocumentElement|MockObject
+     */
+    private $page;
+
+    /**
+     * @var NodeElement|MockObject
+     */
+    private $element;
+
+    /**
+     * @var NodeElement|MockObject
+     */
+    private $button;
+
+    /**
+     * @var DriverInterface|MockObject
+     */
+    private $driver;
+
+    /**
+     * @var WebAssert|MockObject
+     */
+    private $webAssert;
+
+    /**
+     * @var NodeElement|MockObject
+     */
+    private $block;
+
+    /**
+     * @var NodeElement|MockObject
+     */
+    private $tab;
+
+    /**
+     * @var NodeElement|MockObject
+     */
+    private $input;
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function setUp(): void
+    {
+        $this->session   = $this->createMock(Session::class);
+        $this->page      = $this->createMock(DocumentElement::class);
+        $this->element   = $this->createMock(NodeElement::class);
+        $this->button    = $this->createMock(NodeElement::class);
+        $this->driver    = $this->createMock(DriverInterface::class);
+        $this->webAssert = $this->createMock(WebAssert::class);
+        $this->block     = $this->createMock(NodeElement::class);
+        $this->tab       = $this->createMock(NodeElement::class);
+        $this->input     = $this->createMock(NodeElement::class);
+    }
+
+    /**
+     * Test iOpenTheContainerByText method with element found.
+     */
+    public function testIOpenTheContainerByText(): void
+    {
+        /** @var SonataPageAdminTrait|MockObject $trait */
+        $trait = $this->getSonataPageAdminTraitMock();
+
+        $this->element->expects($this->once())->method('click');
+
+        $this->page->expects($this->once())
+             ->method('find')
+             ->with($this->equalTo('css'), $this->equalTo('div.page-composer__page-preview a:contains(\'Content\')'))
+             ->willReturn($this->element)
+        ;
+        $this->session->expects($this->once())->method('getPage')->willReturn($this->page);
+        $trait->expects($this->once())->method('getSession')->willReturn($this->session);
+
+        $trait->iOpenTheContainerByText("Content");
+    }
+
+    /**
+     * Test iOpenTheContainerByText method not found.
+     */
+    public function testIOpenTheContainerByTextNotFound(): void
+    {
+        /** @var SonataPageAdminTrait|MockObject $trait */
+        $trait = $this->getSonataPageAdminTraitMock();
+
+        $this->page->expects($this->once())
+            ->method('find')
+            ->with($this->equalTo('css'), $this->equalTo('div.page-composer__page-preview a:contains(\'Content\')'))
+            ->willReturn(null)
+        ;
+        $this->session->expects($this->once())->method('getPage')->willReturn($this->page);
+        $this->session->expects($this->once())->method('getDriver')->willReturn($this->driver);
+        $trait->expects($this->exactly(2))->method('getSession')->willReturn($this->session);
+        $this->expectExceptionMessage("Tag with text \"Content\" not found.");
+        $this->expectException(ElementNotFoundException::class);
+
+        $trait->iOpenTheContainerByText("Content");
+    }
+
+    /**
+     * Test iAddABlockWithTheName method with element found.
+     */
+    public function testIAddABlockWithTheName(): void
+    {
+        /** @var SonataPageAdminTrait|MockObject $trait */
+        $trait = $this->getSonataPageAdminTraitMock();
+
+        $this->button->expects($this->once())->method('click');
+        $this->page->expects($this->at(0))
+            ->method('find')
+            ->with($this->equalTo('css'), $this->equalTo('a.BlockSelectModal_SelectLink:contains(\'Simple text\')'))
+            ->willReturn($this->button)
+        ;
+
+        $this->page->expects($this->at(1))
+            ->method('find')
+            ->with($this->equalTo('css'), $this->equalTo('li.page-composer__container__child:contains(\'Simple text\') * input.page-composer__container__child__name__input'))
+            ->willReturn($this->input)
+        ;
+
+        $this->input->expects($this->once())->method('setValue');
+
+        $this->session->expects($this->exactly(2))->method('getPage')->willReturn($this->page);
+        $trait->expects($this->once())->method('thePopinShouldBeClosed')->with('blockSelectModal');
+        $trait->expects($this->exactly(2))->method('getSession')->willReturn($this->session);
+        $trait->expects($this->exactly(3))->method('iWaitForCssElementBeingVisible');
+        $trait->expects($this->exactly(1))->method('clickingOnElementShouldOpenPopin')->with('div.page-composer__block-type-selector button', 'blockSelectModal');
+
+        $trait->iAddABlockWithTheName("Simple text", "Foo");
+    }
+
+    /**
+     * Test iAddABlockWithTheName method with button not found.
+     */
+    public function testIAddABlockWithTheNameButtonNotFound(): void
+    {
+        /** @var SonataPageAdminTrait|MockObject $trait */
+        $trait = $this->getSonataPageAdminTraitMock();
+
+        $trait->expects($this->at(0))
+            ->method('iWaitForCssElementBeingVisible')
+            ->with('div.page-composer__block-type-selector button', 2)
+        ;
+
+        $this->page->expects($this->at(0))
+            ->method('find')
+            ->with($this->equalTo('css'), $this->equalTo('a.BlockSelectModal_SelectLink:contains(\'Simple text\')'))
+            ->willReturn(null)
+        ;
+
+        $this->session->expects($this->once())->method('getDriver')->willReturn($this->driver);
+        $this->session->expects($this->once())->method('getPage')->willReturn($this->page);
+        $trait->expects($this->exactly(2))->method('getSession')->willReturn($this->session);
+
+        $this->expectExceptionMessage("Tag with block \"Simple text\" not found.");
+        $this->expectException(ElementNotFoundException::class);
+
+        $trait->iAddABlockWithTheName("Simple text", "Foo");
+    }
+
+    /**
+     * Test iAddBlockWithTheName method with block not found.
+     */
+    public function testIAddBlockWithTheNameBlockNotFound(): void
+    {
+        /** @var SonataPageAdminTrait|MockObject $trait */
+        $trait = $this->getSonataPageAdminTraitMock();
+
+        $this->button->expects($this->once())->method('click');
+
+        $this->page->expects($this->at(0))
+            ->method('find')
+            ->with($this->equalTo('css'), $this->equalTo('a.BlockSelectModal_SelectLink:contains(\'Simple text\')'))
+            ->willReturn($this->button)
+        ;
+
+        $this->page->expects($this->at(1))
+            ->method('find')
+            ->with($this->equalTo('css'), $this->equalTo('li.page-composer__container__child:contains(\'Simple text\') * input.page-composer__container__child__name__input'))
+            ->willReturn(null)
+        ;
+
+        $this->session->expects($this->exactly(1))->method('getDriver')->willReturn($this->driver);
+        $this->session->expects($this->exactly(2))->method('getPage')->willReturn($this->page);
+        $trait->expects($this->exactly(3))->method('getSession')->willReturn($this->session);
+        $trait->expects($this->exactly(3))->method('iWaitForCssElementBeingVisible');
+        $this->expectExceptionMessage("Tag with input \"Simple text\" not found.");
+        $this->expectException(ElementNotFoundException::class);
+
+        $trait->iAddABlockWithTheName("Simple text", "Foo");
+    }
+
+    /**
+     * Test iAddBlockWithTheName method with input not found.
+     */
+    public function testIAddBlockWithTheNameInputNotFound(): void
+    {
+        /** @var SonataPageAdminTrait|MockObject $trait */
+        $trait = $this->getSonataPageAdminTraitMock();
+
+        $this->button->expects($this->once())->method('click');
+
+        $this->page->expects($this->at(0))
+            ->method('find')
+            ->with($this->equalTo('css'), $this->equalTo('a.BlockSelectModal_SelectLink:contains(\'Simple text\')'))
+            ->willReturn($this->button)
+        ;
+
+        $this->page->expects($this->at(1))
+            ->method('find')
+            ->with($this->equalTo('css'), $this->equalTo('li.page-composer__container__child:contains(\'Simple text\') * input.page-composer__container__child__name__input'))
+            ->willReturn(null)
+        ;
+
+        $this->session->expects($this->exactly(1))->method('getDriver')->willReturn($this->driver);
+        $this->session->expects($this->exactly(2))->method('getPage')->willReturn($this->page);
+        $trait->expects($this->any())->method('getSession')->willReturn($this->session);
+        $trait->expects($this->exactly(3))->method('iWaitForCssElementBeingVisible');
+        $this->expectExceptionMessage("Tag with input \"Simple text\" not found.");
+        $this->expectException(ElementNotFoundException::class);
+
+        $trait->iAddABlockWithTheName("Simple text", "Foo");
+    }
+
+    /**
+     * Test iGoToTheTabOfTheBlock method with element found.
+     */
+    public function testIGoToTheTabOfTheBlock(): void
+    {
+        /** @var SonataPageAdminTrait|MockObject $trait */
+        $trait = $this->getSonataPageAdminTraitMock();
+
+        $this->tab->expects($this->once())->method('click');
+        $this->page->expects($this->once())->method('find')
+             ->with($this->equalTo('css'), $this->equalTo('li.page-composer__container__child:contains(\'Foo\') * a:contains(\'English\')'))
+             ->willReturn($this->tab)
+        ;
+
+        $this->session->expects($this->once())->method('getPage')->willReturn($this->page);
+        $trait->expects($this->any())->method('getSession')->willReturn($this->session);
+
+        $trait->iGoToTheTabOfTheBlock("English", "Foo");
+    }
+
+    /**
+     * Test iGoToTheTabOfTheBlock method with element tab not found.
+     */
+    public function testIGoToTheTabOfTheBlockNotFound(): void
+    {
+        /** @var SonataPageAdminTrait|MockObject $trait */
+        $trait = $this->getSonataPageAdminTraitMock();
+
+        $this->tab->expects($this->never())->method('click');
+        $this->page->expects($this->once())->method('find')
+            ->with($this->equalTo('css'), $this->equalTo('li.page-composer__container__child:contains(\'Foo\') * a:contains(\'English\')'))
+            ->willReturn(null)
+        ;
+
+        $this->session->expects($this->once())->method('getDriver')->willReturn($this->driver);
+        $this->session->expects($this->once())->method('getPage')->willReturn($this->page);
+        $trait->expects($this->any())->method('getSession')->willReturn($this->session);
+        $this->expectExceptionMessage("Tag not found.");
+        $this->expectException(ElementNotFoundException::class);
+
+        $trait->iGoToTheTabOfTheBlock("English", "Foo");
+    }
+
+    /**
+     * Test iShouldSeeBlocks method with element found.
+     */
+    public function testIShouldSeeBlocks(): void
+    {
+        /** @var SonataPageAdminTrait|MockObject $trait */
+        $trait = $this->getSonataPageAdminTraitMock();
+
+        $this->page->expects($this->once())->method('find')
+             ->with($this->equalTo('css'), $this->equalTo('div.page-composer__container__view > ul.page-composer__container__children > li'))
+             ->willReturn($this->element)
+        ;
+
+        $trait->expects($this->once())->method('assertNumElements')->with(1, 'div.page-composer__container__view > ul.page-composer__container__children > li');
+        $this->session->expects($this->once())->method('getPage')->willReturn($this->page);
+        $trait->expects($this->once())->method('getSession')->willReturn($this->session);
+
+        $trait->iShouldSeeBlocks(1);
+    }
+
+    /**
+     * Test iShouldSeeBlocks method with element not found.
+     */
+    public function testIShouldSeeBlocksElementNotFound(): void
+    {
+        /** @var SonataPageAdminTrait|MockObject $trait */
+        $trait = $this->getSonataPageAdminTraitMock();
+
+        $this->page->expects($this->once())->method('find')
+            ->with($this->equalTo('css'), $this->equalTo('div.page-composer__container__view > ul.page-composer__container__children > li'))
+            ->willReturn(null)
+        ;
+
+        $this->session->expects($this->once())->method('getDriver')->willReturn($this->driver);
+        $this->session->expects($this->once())->method('getPage')->willReturn($this->page);
+        $trait->expects($this->exactly(2))->method('getSession')->willReturn($this->session);
+        $this->expectExceptionMessage("Tag not found.");
+        $this->expectException(ElementNotFoundException::class);
+
+        $trait->iShouldSeeBlocks(1);
+    }
+
+    /**
+     * Test iOpenTheBlock method with element found.
+     */
+    public function testIOpenTheBlock(): void
+    {
+        /** @var SonataPageAdminTrait|MockObject $trait */
+        $trait = $this->getSonataPageAdminTraitMock();
+
+        $trait->expects($this->once())
+            ->method('iWaitForCssElementBeingVisible')
+            ->with($this->equalTo('li.page-composer__container__child:contains(\'Foo\') > a.page-composer__container__child__edit'), $this->equalTo(2))
+        ;
+        $this->block->expects($this->once())->method('click');
+        $this->page->expects($this->once())->method('find')
+            ->with($this->equalTo('css'), $this->equalTo('li.page-composer__container__child:contains(\'Foo\') > a.page-composer__container__child__edit'))
+            ->willReturn($this->block)
+        ;
+
+        $this->session->expects($this->once())->method('getPage')->willReturn($this->page);
+        $trait->expects($this->once())->method('getSession')->willReturn($this->session);
+
+        $trait->iOpenTheBlock("Foo");
+    }
+
+    /**
+     * Test iOpenTheBlock method with element not found.
+     */
+    public function testIOpenTheBlockNotFound(): void
+    {
+        /** @var SonataPageAdminTrait|MockObject $trait */
+        $trait = $this->getSonataPageAdminTraitMock();
+
+        $this->page->expects($this->once())->method('find')
+            ->with($this->equalTo('css'), $this->equalTo('li.page-composer__container__child:contains(\'Foo\') > a.page-composer__container__child__edit'))
+            ->willReturn(null)
+        ;
+
+        $this->session->expects($this->once())->method('getDriver')->willReturn($this->driver);
+        $this->session->expects($this->once())->method('getPage')->willReturn($this->page);
+        $trait->expects($this->exactly(2))->method('getSession')->willReturn($this->session);
+        $this->expectExceptionMessage("Tag not found.");
+        $this->expectException(ElementNotFoundException::class);
+
+        $trait->iOpenTheBlock("Foo");
+    }
+
+    /**
+     * Test iSubmitTheBlock method with element found.
+     */
+    public function testISubmitTheBlock(): void
+    {
+        /** @var SonataPageAdminTrait|MockObject $trait */
+        $trait = $this->getSonataPageAdminTraitMock();
+
+        $this->block->expects($this->once())->method('press');
+        $this->page->expects($this->once())->method('find')
+            ->with($this->equalTo('css'), $this->equalTo('li.page-composer__container__child:contains(\'Foo\') * button[type=submit]'))
+            ->willReturn($this->block)
+        ;
+
+        $this->session->expects($this->once())->method('getPage')->willReturn($this->page);
+        $trait->expects($this->once())->method('getSession')->willReturn($this->session);
+
+        $trait->iSubmitTheBlock("Foo");
+    }
+
+    /**
+     * Test iSubmitTheBlock method with element not found.
+     */
+    public function testISubmitTheBlockNotFound(): void
+    {
+        /** @var SonataPageAdminTrait|MockObject $trait */
+        $trait = $this->getSonataPageAdminTraitMock();
+
+        $this->page->expects($this->once())->method('find')
+            ->with($this->equalTo('css'), $this->equalTo('li.page-composer__container__child:contains(\'Foo\') * button[type=submit]'))
+            ->willReturn(null)
+        ;
+
+        $this->session->expects($this->once())->method('getDriver')->willReturn($this->driver);
+        $this->session->expects($this->once())->method('getPage')->willReturn($this->page);
+        $trait->expects($this->exactly(2))->method('getSession')->willReturn($this->session);
+        $this->expectExceptionMessage("Tag not found.");
+        $this->expectException(ElementNotFoundException::class);
+
+        $trait->iSubmitTheBlock("Foo");
+    }
+
+    /**
+     * Test iDeleteTheBlock method with element found.
+     */
+    public function testIDeleteTheBlock(): void
+    {
+        /** @var SonataPageAdminTrait|MockObject $trait */
+        $trait = $this->getSonataPageAdminTraitMock();
+
+        $this->page->expects($this->at(0))
+            ->method('find')
+            ->with($this->equalTo('css'), $this->equalTo('li:contains(\'Foo\')'))
+            ->willReturn($this->element)
+        ;
+        $this->element->expects($this->once())->method('getAttribute')->with('data-block-id')->willReturn(1);
+        $this->page->expects($this->at(1))
+            ->method('find')
+            ->with($this->equalTo('css'), $this->equalTo('li.page-composer__container__child:contains(\'Foo\') > a.page-composer__container__child__edit'))
+            ->willReturn($this->element)
+        ;
+
+        $this->page->expects($this->at(2))
+            ->method('find')
+            ->with($this->equalTo('css'), $this->equalTo('li.page-composer__container__child[data-block-id=1] * a.btn-danger'))
+            ->willReturn($this->button)
+        ;
+        $this->page->expects($this->at(3))
+            ->method('find')
+            ->with($this->equalTo('css'), $this->equalTo('button.btn-danger'))
+            ->willReturn($this->button)
+        ;
+
+        $this->button->expects($this->once())->method('click');
+
+        $this->element->expects($this->once())->method('getAttribute')->with('data-block-id')->willReturn(1);
+        $this->session->expects($this->exactly(4))->method('getPage')->willReturn($this->page);
+        $trait->expects($this->exactly(5))->method('getSession')->willReturn($this->session);
+
+        $trait->iDeleteTheBlock("Foo");
+    }
+
+    /**
+     * Test testIDeleteTheBlock method with element not found.
+     */
+    public function testIDeleteTheBlockElementNotFound(): void
+    {
+        /** @var SonataPageAdminTrait|MockObject $trait */
+        $trait = $this->getSonataPageAdminTraitMock();
+
+        $this->page->expects($this->at(0))
+            ->method('find')
+            ->with($this->equalTo('css'), $this->equalTo('li:contains(\'Foo\')'))
+            ->willReturn(null)
+        ;
+
+        $this->expectExceptionMessage("Tag not found.");
+        $this->expectException(ElementNotFoundException::class);
+        $this->session->expects($this->once())->method('getDriver')->willReturn($this->driver);
+        $this->session->expects($this->once())->method('getPage')->willReturn($this->page);
+        $trait->expects($this->exactly(2))->method('getSession')->willReturn($this->session);
+        $trait->iDeleteTheBlock("Foo");
+    }
+
+    /**
+     * Test testIDeleteTheBlock method with button not found.
+     */
+    public function testIDeleteTheBlockButtonNotFound(): void
+    {
+        /** @var SonataPageAdminTrait|MockObject $trait */
+        $trait = $this->getSonataPageAdminTraitMock();
+
+        $this->page->expects($this->at(0))
+            ->method('find')
+            ->with($this->equalTo('css'), $this->equalTo('li:contains(\'Foo\')'))
+            ->willReturn($this->element)
+        ;
+        $this->element->expects($this->once())->method('getAttribute')->with('data-block-id')->willReturn(1);
+        $this->page->expects($this->at(1))->method('find')
+            ->with($this->equalTo('css'), $this->equalTo('li.page-composer__container__child:contains(\'Foo\') > a.page-composer__container__child__edit'))
+            ->willReturn($this->element)
+        ;
+
+        $this->page->expects($this->at(2))
+            ->method('find')
+            ->with($this->equalTo('css'), $this->equalTo('li.page-composer__container__child[data-block-id=1] * a.btn-danger'))
+            ->willReturn(null)
+        ;
+
+        $this->expectExceptionMessage("Tag not found.");
+        $this->expectException(ElementNotFoundException::class);
+        $this->session->expects($this->once())->method('getDriver')->willReturn($this->driver);
+        $this->session->expects($this->exactly(3))->method('getPage')->willReturn($this->page);
+        $trait->expects($this->exactly(4))->method('getSession')->willReturn($this->session);
+
+        $trait->iDeleteTheBlock("Foo");
+    }
+
+    /**
+     * Test iRenameTheBlock method with element found.
+     */
+    public function testIRenameTheBlock(): void
+    {
+        /** @var SonataPageAdminTrait|MockObject $trait */
+        $trait = $this->getSonataPageAdminTraitMock();
+
+        $trait->expects($this->at(0))
+            ->method('iWaitForCssElementBeingVisible')
+            ->with('li.page-composer__container__child:contains(\'Foo\') > a.page-composer__container__child__edit', 2)
+        ;
+
+        $this->input->expects($this->once())->method('setValue')->with("Bar");
+        $this->button->expects($this->once())->method('press');
+        $this->element->expects($this->any())->method('getAttribute')->with('data-block-id')->willReturn(1);
+
+        $this->page->expects($this->at(0))
+            ->method('find')
+            ->with($this->equalTo('css'), $this->equalTo('li.page-composer__container__child:contains(\'Foo\') > a.page-composer__container__child__edit'))
+            ->willReturn($this->element)
+        ;
+        $this->page->expects($this->at(1))
+            ->method('find')
+            ->with($this->equalTo('css'), $this->equalTo('li:contains(\'Foo\')'))
+            ->willReturn($this->element)
+        ;
+        $this->page->expects($this->at(2))
+            ->method('find')
+            ->with($this->equalTo('css'), $this->equalTo('li[data-block-id=1] * input.page-composer__container__child__name__input'))
+            ->willReturn($this->input)
+        ;
+        $this->page->expects($this->at(3))
+            ->method('find')
+            ->with($this->equalTo('css'), $this->equalTo('li[data-block-id=1] * button[type=submit]'))
+            ->willReturn($this->button)
+        ;
+
+        $this->session->expects($this->exactly(4))->method('getPage')->willReturn($this->page);
+        $trait->expects($this->exactly(4))->method('getSession')->willReturn($this->session);
+        $trait->iRenameTheBlock("Foo", "Bar");
+    }
+
+    /**
+     * Test iRenameTheBlock method with element found.
+     */
+    public function testIRenameTheBlockInputNotFound(): void
+    {
+        /** @var SonataPageAdminTrait|MockObject $trait */
+        $trait = $this->getSonataPageAdminTraitMock();
+
+        $this->page->expects($this->at(0))
+            ->method('find')
+            ->with($this->equalTo('css'), $this->equalTo('li.page-composer__container__child:contains(\'Foo\') > a.page-composer__container__child__edit'))
+            ->willReturn(null)
+        ;
+
+        $this->session->expects($this->once())->method('getDriver')->willReturn($this->driver);
+        $this->session->expects($this->once())->method('getPage')->willReturn($this->page);
+        $trait->expects($this->exactly(2))->method('getSession')->willReturn($this->session);
+        $this->expectExceptionMessage("Tag not found.");
+        $this->expectException(ElementNotFoundException::class);
+
+        $trait->iRenameTheBlock("Foo", "Bar");
+    }
+
+    /**
+     * Test theBlockShouldBeOpened method with element found.
+     */
+    public function testTheBlockShouldBeOpened(): void
+    {
+        /** @var SonataPageAdminTrait|MockObject $trait */
+        $trait = $this->getSonataPageAdminTraitMock();
+
+        $this->page->expects($this->once())
+            ->method('find')
+            ->with($this->equalTo('css'), $this->equalTo('li:contains(\'Foo\')'))
+            ->willReturn($this->element)
+        ;
+
+        $this->element->expects($this->once())->method('getAttribute')->willReturn(1);
+        $this->session->expects($this->once())->method('getPage')->willReturn($this->page);
+        $trait->expects($this->once())->method('getSession')->willReturn($this->session);
+
+        $this->webAssert->expects($this->once())
+            ->method('elementContains')
+            ->with($this->equalTo('css'), $this->equalTo('li.page-composer__container__child[data-block-id=1] > div.page-composer__container__child__content'), $this->equalTo('form'))
+        ;
+
+        $trait->expects($this->once())->method('assertSession')->willReturn($this->webAssert);
+
+        $trait->theBlockShouldBeOpened("Foo");
+    }
+
+    /**
+     * Test theBlockShouldBeOpened method with element not found.
+     */
+    public function testTheBlockShouldBeOpenedNotFound(): void
+    {
+        /** @var SonataPageAdminTrait|MockObject $trait */
+        $trait = $this->getSonataPageAdminTraitMock();
+
+        $this->page->expects($this->once())
+            ->method('find')
+            ->with($this->equalTo('css'), $this->equalTo('li:contains(\'Foo\')'))
+            ->willReturn(null)
+        ;
+
+        $this->session->expects($this->once())->method('getDriver')->willReturn($this->driver);
+        $this->session->expects($this->once())->method('getPage')->willReturn($this->page);
+        $trait->expects($this->exactly(2))->method('getSession')->willReturn($this->session);
+        $this->expectExceptionMessage("Tag not found.");
+        $this->expectException(ElementNotFoundException::class);
+
+        $trait->theBlockShouldBeOpened("Foo");
+    }
+
+    /**
+     * Test theBlockShouldBeClosed method with element found.
+     */
+    public function testTheBlockShouldBeClosed(): void
+    {
+        /** @var SonataPageAdminTrait|MockObject $trait */
+        $trait = $this->getSonataPageAdminTraitMock();
+
+        $trait->expects($this->once())->method('iWaitForCssElementBeingVisible')->with('li.page-composer__container__child:contains(\'Foo\')');
+
+        $this->page->expects($this->once())
+            ->method('find')
+            ->with($this->equalTo('css'), $this->equalTo('li.page-composer__container__child:contains(\'Foo\')'))
+            ->willReturn($this->element)
+        ;
+
+        $trait->expects($this->once())
+             ->method('elementAttributeNotContains')
+             ->with($this->equalTo('li.page-composer__container__child:contains(\'Foo\')'), $this->equalTo('class'), $this->equalTo('page-composer__container__child--expanded'))
+        ;
+
+        $this->session->expects($this->once())->method('getPage')->willReturn($this->page);
+        $trait->expects($this->once())->method('getSession')->willReturn($this->session);
+
+        $trait->theBlockShouldBeClosed("Foo");
+    }
+
+    /**
+     * Test theBlockShouldBeClosed method element not found.
+     */
+    public function testTheBlockShouldBeClosedNotFound(): void
+    {
+        /** @var SonataPageAdminTrait|MockObject $trait */
+        $trait = $this->getSonataPageAdminTraitMock();
+
+        $trait->expects($this->once())->method('iWaitForCssElementBeingVisible')->with($this->equalTo('li.page-composer__container__child:contains(\'Foo\')'));
+
+        $this->page->expects($this->once())
+            ->method('find')
+            ->with($this->equalTo('css'), $this->equalTo('li.page-composer__container__child:contains(\'Foo\')'))
+            ->willReturn(null)
+        ;
+
+        $this->session->expects($this->once())->method('getDriver')->willReturn($this->driver);
+        $this->session->expects($this->once())->method('getPage')->willReturn($this->page);
+        $trait->expects($this->exactly(2))->method('getSession')->willReturn($this->session);
+        $this->expectExceptionMessage("Tag not found.");
+        $this->expectException(ElementNotFoundException::class);
+
+        $trait->theBlockShouldBeClosed("Foo");
+    }
+
+    /**
+     * @return MockObject
+     */
+    private function getSonataPageAdminTraitMock(): MockObject
+    {
+        return $this->getMockForTrait(
+            SonataPageAdminTrait::class,
+            [],
+            '',
+            true,
+            true,
+            true,
+            [
+                'assertNumElements',
+                'assertSession',
+                'clickingOnElementShouldOpenPopin',
+                'elementAttributeNotContains',
+                'getAttribute',
+                'getSession',
+                'iWaitForCssElementBeingVisible',
+                'setValue',
+                'thePopinShouldBeOpened',
+                'thePopinShouldBeClosed',
+                'visit',
+                'waitForSeconds'
+            ]
+        );
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - master is for everything backwards compatible, like patches, features and deprecation notices
-->
I am targeting this branch, because I add many behat helpers for SonataPage bundle.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added some behat helpers with `SonataPageAdminTrait.php` trait.
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->
- [x] Add SonataPageAdminTrait
- [x] Update the documentaion
- [x] Update the tests

## Subject
New steps availables:

| Step | Regex |
| --- | --- |
| I open the container "Content" | `/^I open the container "([^"]*)"$/` |
| I add the block "Simple text" with the name "Foo" | `/^I add the block "([^"]*)" with the name "([^"]*)"$/` |
| I go to the tab "English" of the block "Foo" | `/^I go to the tab "([^"]*)" of the block "([^"]*)"$/` |
| I should see 6 blocks | `/^I should see (\d+) blocks$/` |
| I open the block "Foo" | `/^I open the block "([^"]*)"$/` |
| I submit the block "Foo" | `/^I submit the block "([^"]*)"$/` |
| I delete the block "Foo" | `/^I delete the block "([^"]*)"$/` |
| I rename the block "Foo" with "Bar" | `/^I rename the block "([^"]*)" with "([^"]*)"$/` |
| The block "Foo" should be opened | `/^The block "([^"]*)" should be opened$/` |
| The block "Foo" should be closed | `/^The block "([^"]*)" should be closed$/` |
<!-- Describe your Pull Request content here -->
