### PR TITLE
feat(README): add doc for all available steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 master
 ------
 
+* Add doc for all available steps
 * Add helpers for sonata-project/page-bundle
 
 v0.1.1

--- a/README.md
+++ b/README.md
@@ -122,6 +122,16 @@ Scenario: foo elt should be visible in 2 seconds or less
     Then I wait for "foo" element being visible for 2 seconds
 ```
 
+| Step | Regex |
+| --- | --- |
+| I wait for 2 seconds | `/^I wait for (\d+) seconds?$/` |
+| I wait for "foo" element being visible for 2 seconds | `/^I wait for "([^"]*)" element being visible for (\d+) seconds$/` |
+| I wait for "Foo" element being invisible for 2 seconds | `/^I wait for "([^"]*)" element being invisible for (\d+) seconds$/` |
+| I scroll to 123 and 987 | `/^I scroll to (\d+) and (\d+)?$/` |
+| I wait 3 seconds that page contains text "Foo" | `/^I wait (\d+) seconds that page contains text "([^"]*)"$/` |
+| I wait 3 seconds that page not contains text "Bar" | `/^I wait (\d+) seconds that page not contains text "([^"]*)"$/` |
+| I click on button containing "Foo" | `/^I click on (?:link`&#x7c;`button) containing "(?P<text>[^"]*)"$/` |
+
 ### ExtraWebAssertTrait
 
 This trait provides some extra asserts.
@@ -139,6 +149,12 @@ class MyFeatureContext extends MinkContext
     use ExtraWebAssertTrait;
 }
 ```
+
+| Step | Regex |
+| --- | --- |
+| the "Foo" element should have attribute "Bar" | `/^the "(?P<element>[^"]*)" element should have attribute "(?P<value>(?:[^"]|\\")*)"$/` |
+| I click the "Foo" element| `/^I click the "(?P<element>[^"]*)" element$/` |
+| I should see at least 2 "Bar" elements | `/^(?:|I )should see at least (?P<num>\d+) "(?P<element>[^"]*)" elements?$/` |
 
 ### ReloadCookiesTrait
 
@@ -215,6 +231,11 @@ Scenario: I am on /step1 if previous cookies are reset
     Then I should be on "/step3"
     But I am on "/step1"
 ```
+
+| Step | Regex |
+| --- | --- |
+| I fill the first step | `/^I fill the first step$/` |
+| I fill the second step | `/^I fill the second step$/` |
 
 ### ReloadDatabaseTrait
 
@@ -339,6 +360,20 @@ Scenario: I can login and then access to the admin dashboard
     And I should see "Welcome to the admin dashboard"
 ```
 
+| Step | Regex |
+| --- | --- |
+| I open the menu "Foo" | `/^I open the menu "([^"]*)"$/` |
+| I should see "Foo" action in navbar | `/^I should see "([^"]*)" action in navbar$/` |
+| I should not see "Foo" action in navbar | `/^I should not see "([^"]*)" action in navbar$/` |
+| I click on "Foo" action in navbar | `/^I click on "([^"]*)" action in navbar$/` |
+| clicking on the "Foo" element should open a popin "Bar" | `/^clicking on the "([^"]*)" element should open a popin "([^"]*)"$/` |
+| the popin "Foo" should be closed | `/^the popin "([^"]*)" should be closed$/` |
+| the popin "Foo" should not be opened | `/^the popin "([^"]*)" should not be opened$/` |
+| the popin "Foo" should be opened | `/^the popin "([^"]*)" should be opened$/` |
+| I set the select2 field "Foo" to "Bar" | `/^(?:`&#x7c;`I )set the select2 field "(?P<field>(?:[^"]`&#x7c;`\\")*)" to "(?P<textValues>(?:[^"]`&#x7c;`\\")*)"$/` |
+| I set the select2 value "Foo" for "Bar" | `/^(?:`&#x7c;`I )set the select2 value "(?P<textValues>(?:[^"]`&#x7c;`\\")*)" for "(?P<field>(?:[^"]`&#x7c;`\\")*)"$/` |
+
+
 ### SonataPageAdminTrait
 
 This trait integrates [sonata-project/page-bundle][4] with some basics like interaction with container, block...
@@ -389,6 +424,7 @@ And       I delete the block "Bar"
 | I rename the block "Foo" with "Bar" | `/^I rename the block "([^"]*)" with "([^"]*)"$/` |
 | The block "Foo" should be opened | `/^The block "([^"]*)" should be opened$/` |
 | The block "Foo" should be closed | `/^The block "([^"]*)" should be closed$/` |
+
 
 [1]: https://github.com/Behat/Symfony2Extension
 [2]: https://github.com/doctrine/DoctrineBundle


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - master is for everything backwards compatible, like patches, features and deprecation notices
-->
I am targeting this branch, because I add an array of steps availables for each behat-helpers.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added documentation for all available steps in `README.md`

```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [x] Update the documentation

## Subject

I added documentation for all availables steps to existante behat-helpers for more readibility.