### PR TITLE
fix(router): fix RouterAwareTrait when route is defined for only one host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG
 master
 ------
 
+* Fix RouterAwareTrait for route with host restriction
+
 v0.2.0
 ------
 

--- a/src/RouterAwareTrait.php
+++ b/src/RouterAwareTrait.php
@@ -46,6 +46,11 @@ trait RouterAwareTrait
             $url = $path;
         }
 
+        // remove host added by router when host is specified in route definition
+        if (preg_match('#^(https?:)?(//)?([^/]+)(.*)$#', $url, $matches)) {
+            $url = $matches[4] ?? $url;
+        }
+
         $locatedPath = parent::locatePath($url);
 
         // add logs, captured by Behat


### PR DESCRIPTION
I am targeting this branch, because there is the only one.

## Changelog
Fix RouterAwareTrait when route is defined for only one host

```markdown
### Fixed
Fix RouterAwareTrait when route is defined for only one host
```

## Subject

When a route is defined with a host restriction, generated url with router will start with the defined host. Then Mink will add the base_url resulting into an url formatted as follow: https://<host>/<host>/<path>. This MR fix it by removing base_url if the generated route starts with it
