### PR TITLE
chore(dependencies): bump dependencies to allow SF5 and disallow SF2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ master
 
 * Fix RouterAwareTrait for route with host restriction
 * Switch to the new security checker
+* Bump dependencies to allow SF5 and disallow SF2
 
 v0.2.0
 ------

--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,12 @@
         "behat/mink-selenium2-driver": "^1.3",
         "behat/symfony2-extension":    "^2.1",
         "cocur/slugify":               "^3.1 || ^4.0",
-        "symfony/stopwatch":           "^2.8 || ^3.0 || ^4.0"
+        "symfony/stopwatch":           "^3.4 || ^4.4 || ^5.0"
     },
     "require-dev": {
         "phpunit/phpunit":             "^7.5",
-        "friendsofphp/php-cs-fixer":   "^2.13",
-        "ekino/phpstan-banned-code":   "^0.1",
+        "friendsofphp/php-cs-fixer":   "^2.18",
+        "ekino/phpstan-banned-code":   "^0.2",
         "phpstan/phpstan":             "^0.11",
         "phpstan/phpstan-phpunit":     "^0.11"
     },


### PR DESCRIPTION

I am targeting this branch, because there is no BC breack

## Changelog

```markdown
### Changed
- Bump dependencies to allow SF5 and disallow SF2
```