### PR TITLE
feat(php8): allow php8 and drop PHP7.1 support

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -1,13 +1,17 @@
 name: Tests
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron:  '0 1 * * *'
 
 jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ '7.1', '7.2', '7.3', '7.4' ]
+        php: [ '7.2', '7.3', '7.4', '8.0' ]
     steps:
       - uses: actions/checkout@v2
       - name: Setup PHP with tools

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ master
 
 * Fix RouterAwareTrait for route with host restriction
 * Switch to the new security checker
+* Drop support PHP7.1
+* Allow PHP8
 
 v0.2.0
 ------

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php":                         "^7.1",
+        "php":                         "^7.2 || ^8.0",
         "behat/mink-extension":        "^2.3",
         "behat/mink-selenium2-driver": "^1.3",
         "behat/symfony2-extension":    "^2.1",
@@ -21,11 +21,11 @@
         "symfony/stopwatch":           "^2.8 || ^3.0 || ^4.0"
     },
     "require-dev": {
-        "phpunit/phpunit":             "^7.5",
+        "phpunit/phpunit":             "^8.5",
         "friendsofphp/php-cs-fixer":   "^2.13",
-        "ekino/phpstan-banned-code":   "^0.1",
-        "phpstan/phpstan":             "^0.11",
-        "phpstan/phpstan-phpunit":     "^0.11"
+        "ekino/phpstan-banned-code":   "^0.4",
+        "phpstan/phpstan":             "^0.12",
+        "phpstan/phpstan-phpunit":     "^0.12"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -2,16 +2,27 @@ includes:
 	- vendor/phpstan/phpstan-phpunit/extension.neon
 	- vendor/phpstan/phpstan-phpunit/rules.neon
 
+parametersSchema:
+	banned_code: structure([
+		nodes: arrayOf(structure([
+			type: string()
+			functions: schema(arrayOf(string()), nullable())
+		]))
+		use_from_tests: bool()
+	])
+
 parameters:
 	banned_code:
 		nodes:
 			# enable detection of eval
 			-
 				type: Expr_Eval
+				functions:
 
 			# enable detection of die/exit
 			-
 				type: Expr_Exit
+				functions:
 
 			# enable detection of a set of functions
 			-
@@ -32,11 +43,11 @@ parameters:
 
 services:
 	-
-		class: Ekino\PHPStanBannedCode\Rules\BannedNodesRule(%banned_code.nodes%)
+		factory: Ekino\PHPStanBannedCode\Rules\BannedNodesRule(%banned_code.nodes%)
 		tags:
 			- phpstan.rules.rule
 
 	-
-		class: Ekino\PHPStanBannedCode\Rules\BannedUseTestRule(%banned_code.use_from_tests%)
+		factory: Ekino\PHPStanBannedCode\Rules\BannedUseTestRule(%banned_code.use_from_tests%)
 		tags:
 			- phpstan.rules.rule

--- a/src/BaseUrlTrait.php
+++ b/src/BaseUrlTrait.php
@@ -45,7 +45,10 @@ trait BaseUrlTrait
      */
     public function setBaseUrlBeforeScenario(BeforeScenarioScope $scope): void
     {
-        foreach ($scope->getEnvironment()->getContexts() as $context) {
+        /** @var \Behat\Behat\Context\Environment\InitializedContextEnvironment $env */
+        $env = $scope->getEnvironment();
+
+        foreach ($env->getContexts() as $context) {
             if ($context instanceof RawMinkContext) {
                 $context->setMinkParameter('base_url', $this->baseUrl);
             }

--- a/src/DebugTrait.php
+++ b/src/DebugTrait.php
@@ -88,7 +88,9 @@ trait DebugTrait
             return;
         }
 
-        if (!\in_array(KernelDictionary::class, class_uses($this))) {
+        /** @var array<string> $traits */
+        $traits = class_uses($this);
+        if (!\in_array(KernelDictionary::class, $traits)) {
             throw new \RuntimeException(sprintf('Please use the trait %s in the class %s', KernelDictionary::class, __CLASS__));
         }
 

--- a/src/ExtraWebAssertTrait.php
+++ b/src/ExtraWebAssertTrait.php
@@ -81,7 +81,7 @@ trait ExtraWebAssertTrait
     {
         $elements = $this->getSession()->getPage()->findAll('css', $selector);
 
-        if (null === $elements) {
+        if (!$elements) {
             throw new ElementNotFoundException($this->getSession()->getDriver(), 'element', 'css', $selector);
         }
 
@@ -109,7 +109,7 @@ trait ExtraWebAssertTrait
     {
         $elements = $this->getSession()->getPage()->findAll('css', $selector);
 
-        if (null === $elements) {
+        if (!$elements) {
             throw new ElementNotFoundException($this->getSession()->getDriver(), 'element', 'css', $selector);
         }
 

--- a/src/ReloadCookiesTrait.php
+++ b/src/ReloadCookiesTrait.php
@@ -23,12 +23,12 @@ use Behat\Mink\Driver\Selenium2Driver;
 trait ReloadCookiesTrait
 {
     /**
-     * @var array
+     * @var array<mixed>
      */
     private static $steps = [];
 
     /**
-     * @var array
+     * @var array<mixed>
      */
     private static $cookies = [];
 

--- a/src/SonataAdminTrait.php
+++ b/src/SonataAdminTrait.php
@@ -128,7 +128,10 @@ trait SonataAdminTrait
      */
     public function clickingOnElementShouldOpenPopin(string $element, string $popinIdEnding): void
     {
-        if (!\in_array(ExtraSessionTrait::class, class_uses($this))) {
+        /** @var array<string> $traits */
+        $traits = class_uses($this);
+
+        if (!\in_array(ExtraSessionTrait::class, $traits)) {
             throw new \RuntimeException(sprintf('Please use the trait %s in the class %s', ExtraSessionTrait::class, __CLASS__));
         }
 
@@ -148,7 +151,10 @@ trait SonataAdminTrait
      */
     public function thePopinShouldBeClosed(string $popinIdEnding): void
     {
-        if (!\in_array(ExtraSessionTrait::class, class_uses($this))) {
+        /** @var array<string> $traits */
+        $traits = class_uses($this);
+
+        if (!\in_array(ExtraSessionTrait::class, $traits)) {
             throw new \RuntimeException(sprintf('Please use the trait %s in the class %s', ExtraSessionTrait::class, __CLASS__));
         }
 
@@ -218,7 +224,10 @@ trait SonataAdminTrait
         $page   = $this->getSession()->getPage();
         $values = [];
 
-        foreach (preg_split('/,\s*/', $textValues) as $value) {
+        /** @var array<string> $arrayTextValues */
+        $arrayTextValues = preg_split('/,\s*/', $textValues);
+
+        foreach ($arrayTextValues as $value) {
             $option   = $page->find('xpath', sprintf('//select[@id="%s"]//option[text()="%s"]', $field, $value));
             $values[] = $option->getAttribute('value');
         }

--- a/src/SonataPageAdminTrait.php
+++ b/src/SonataPageAdminTrait.php
@@ -241,7 +241,7 @@ trait SonataPageAdminTrait
         $input = $this->getSession()->getPage()->find('css', $element);
 
         if (null === $input) {
-            throw new ElementNotFoundException($this->getSession()->getDriver(), null, 'input', $block);
+            throw new ElementNotFoundException($this->getSession()->getDriver(), null, 'input', $oldName);
         }
 
         $input->setValue($newName);

--- a/tests/BaseUrlTraitTest.php
+++ b/tests/BaseUrlTraitTest.php
@@ -40,9 +40,9 @@ class BaseUrlTraitTest extends TestCase
 
         $scope = new BeforeScenarioScope($env, $this->createMock(FeatureNode::class), $this->createMock(ScenarioInterface::class));
 
-        /** @var BaseUrlTrait $mock */
-        $mock = $this->getMockForTrait(BaseUrlTrait::class);
-        $mock->setBaseUrl('https://foo.bar');
-        $mock->setBaseUrlBeforeScenario($scope);
+        $trait = $this->getMockForTrait(BaseUrlTrait::class);
+
+        $trait->setBaseUrl('https://foo.bar'); // @phpstan-ignore-line
+        $trait->setBaseUrlBeforeScenario($scope); // @phpstan-ignore-line
     }
 }

--- a/tests/ExtraSessionTraitTest.php
+++ b/tests/ExtraSessionTraitTest.php
@@ -16,8 +16,8 @@ namespace Tests\Ekino\BehatHelpers;
 use Behat\Mink\Driver\DriverInterface;
 use Behat\Mink\Element\DocumentElement;
 use Behat\Mink\Element\NodeElement;
+use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\Mink\Session;
-use Behat\MinkExtension\Context\RawMinkContext;
 use Ekino\BehatHelpers\ExtraSessionTrait;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -41,11 +41,10 @@ class ExtraSessionTraitTest extends TestCase
         $driver->expects($this->once())->method('maximizeWindow');
         $session->expects($this->once())->method('getDriver')->willReturn($driver);
 
-        /** @var ExtraSessionTrait|MockObject $mock */
-        $mock = $this->getExtraSessionMock();
-        $mock->expects($this->once())->method('getSession')->willReturn($session);
+        $trait = $this->getExtraSessionMock();
+        $trait->expects($this->once())->method('getSession')->willReturn($session);
 
-        $mock->maximizeWindowOnBeforeScenario();
+        $trait->maximizeWindowOnBeforeScenario(); // @phpstan-ignore-line
     }
 
     /**
@@ -56,11 +55,10 @@ class ExtraSessionTraitTest extends TestCase
         $session = $this->createMock(Session::class);
         $session->expects($this->once())->method('executeScript')->with($this->equalTo('(function(){window.scrollTo(0, 10);})();'));
 
-        /** @var ExtraSessionTrait|MockObject $mock */
-        $mock = $this->getExtraSessionMock();
-        $mock->expects($this->once())->method('getSession')->willReturn($session);
+        $trait = $this->getExtraSessionMock();
+        $trait->expects($this->once())->method('getSession')->willReturn($session);
 
-        $mock->scrollTo(0, 10);
+        $trait->scrollTo(0, 10); // @phpstan-ignore-line
     }
 
     /**
@@ -71,11 +69,10 @@ class ExtraSessionTraitTest extends TestCase
         $session = $this->createMock(Session::class);
         $session->expects($this->once())->method('wait')->with($this->equalTo(1000));
 
-        /** @var ExtraSessionTrait|MockObject $mock */
-        $mock = $this->getExtraSessionMock();
-        $mock->expects($this->once())->method('getSession')->willReturn($session);
+        $trait = $this->getExtraSessionMock();
+        $trait->expects($this->once())->method('getSession')->willReturn($session);
 
-        $mock->waitForSeconds(1);
+        $trait->waitForSeconds(1); // @phpstan-ignore-line
     }
 
     /**
@@ -90,19 +87,19 @@ class ExtraSessionTraitTest extends TestCase
             ->willReturn(true)
         ;
 
-        /** @var ExtraSessionTrait|MockObject $mock */
-        $mock = $this->getExtraSessionMock();
-        $mock->expects($this->once())->method('getSession')->willReturn($session);
-        $mock->iWaitForCssElementBeingVisible('foo', 2);
+        $trait = $this->getExtraSessionMock();
+        $trait->expects($this->once())->method('getSession')->willReturn($session);
+
+        $trait->iWaitForCssElementBeingVisible('foo', 2); // @phpstan-ignore-line
     }
 
     /**
      * Tests the iWaitForCssElementBeingVisible FAIL method.
-     *
-     * @expectedException \RuntimeException
      */
     public function testIWaitForCssElementBeingVisibleFail(): void
     {
+        $this->expectException(\RuntimeException::class);
+
         $session = $this->createMock(Session::class);
         $session->expects($this->once())
             ->method('wait')
@@ -110,10 +107,10 @@ class ExtraSessionTraitTest extends TestCase
             ->willReturn(false)
         ;
 
-        /** @var ExtraSessionTrait|MockObject $mock */
-        $mock = $this->getExtraSessionMock();
-        $mock->expects($this->once())->method('getSession')->willReturn($session);
-        $mock->iWaitForCssElementBeingVisible('foo', 2);
+        $trait = $this->getExtraSessionMock();
+        $trait->expects($this->once())->method('getSession')->willReturn($session);
+
+        $trait->iWaitForCssElementBeingVisible('foo', 2); // @phpstan-ignore-line
     }
 
     /**
@@ -128,19 +125,19 @@ class ExtraSessionTraitTest extends TestCase
             ->willReturn(true)
         ;
 
-        /** @var ExtraSessionTrait|MockObject $mock */
-        $mock = $this->getExtraSessionMock();
-        $mock->expects($this->once())->method('getSession')->willReturn($session);
-        $mock->iWaitForCssElementBeingInvisible('foo', 2);
+        $trait = $this->getExtraSessionMock();
+        $trait->expects($this->once())->method('getSession')->willReturn($session);
+
+        $trait->iWaitForCssElementBeingInvisible('foo', 2); // @phpstan-ignore-line
     }
 
     /**
      * Tests the iWaitForCssElementBeingInvisible FAIL method.
-     *
-     * @expectedException \RuntimeException
      */
     public function testIWaitForCssElementBeingInvisibleFail(): void
     {
+        $this->expectException(\RuntimeException::class);
+
         $session = $this->createMock(Session::class);
         $session->expects($this->once())
             ->method('wait')
@@ -148,10 +145,10 @@ class ExtraSessionTraitTest extends TestCase
             ->willReturn(false)
         ;
 
-        /** @var ExtraSessionTrait|MockObject $mock */
-        $mock = $this->getExtraSessionMock();
-        $mock->expects($this->once())->method('getSession')->willReturn($session);
-        $mock->iWaitForCssElementBeingInvisible('foo', 2);
+        $trait = $this->getExtraSessionMock();
+        $trait->expects($this->once())->method('getSession')->willReturn($session);
+
+        $trait->iWaitForCssElementBeingInvisible('foo', 2); // @phpstan-ignore-line
     }
 
     /**
@@ -171,19 +168,19 @@ class ExtraSessionTraitTest extends TestCase
             ->willReturn($page)
         ;
 
-        /** @var ExtraSessionTrait|MockObject $mock */
-        $mock = $this->getExtraSessionMock();
-        $mock->expects($this->once())->method('getSession')->willReturn($session);
-        $mock->iWaitPageContains(2, 'foo');
+        $trait = $this->getExtraSessionMock();
+        $trait->expects($this->once())->method('getSession')->willReturn($session);
+
+        $trait->iWaitPageContains(2, 'foo'); // @phpstan-ignore-line
     }
 
     /**
      * Tests the method iWaitPageContains FAIL method.
-     *
-     * @expectedException \RuntimeException
      */
     public function testIWaitPageContainsFail(): void
     {
+        $this->expectException(\RuntimeException::class);
+
         $page = $this->createMock(DocumentElement::class);
         $page->expects($this->once())
             ->method('waitFor')
@@ -196,10 +193,10 @@ class ExtraSessionTraitTest extends TestCase
             ->willReturn($page)
         ;
 
-        /** @var ExtraSessionTrait|MockObject $mock */
-        $mock = $this->getExtraSessionMock();
-        $mock->expects($this->once())->method('getSession')->willReturn($session);
-        $mock->iWaitPageContains(2, 'foo');
+        $trait = $this->getExtraSessionMock();
+        $trait->expects($this->once())->method('getSession')->willReturn($session);
+
+        $trait->iWaitPageContains(2, 'foo'); // @phpstan-ignore-line
     }
 
     /**
@@ -219,19 +216,19 @@ class ExtraSessionTraitTest extends TestCase
             ->willReturn($page)
         ;
 
-        /** @var ExtraSessionTrait|MockObject $mock */
-        $mock = $this->getExtraSessionMock();
-        $mock->expects($this->once())->method('getSession')->willReturn($session);
-        $mock->iWaitPageNotContains(2, 'foo');
+        $trait = $this->getExtraSessionMock();
+        $trait->expects($this->once())->method('getSession')->willReturn($session);
+
+        $trait->iWaitPageNotContains(2, 'foo'); // @phpstan-ignore-line
     }
 
     /**
      * Tests the method iWaitPageNotContains Fail method.
-     *
-     * @expectedException \RuntimeException
      */
     public function testIWaitPageNotContainsFail(): void
     {
+        $this->expectException(\RuntimeException::class);
+
         $page = $this->createMock(DocumentElement::class);
         $page->expects($this->once())
             ->method('waitFor')
@@ -244,20 +241,20 @@ class ExtraSessionTraitTest extends TestCase
             ->willReturn($page)
         ;
 
-        /** @var ExtraSessionTrait|MockObject $mock */
-        $mock = $this->getExtraSessionMock();
-        $mock->expects($this->once())->method('getSession')->willReturn($session);
-        $mock->iWaitPageNotContains(2, 'foo');
+        $trait = $this->getExtraSessionMock();
+        $trait->expects($this->once())->method('getSession')->willReturn($session);
+
+        $trait->iWaitPageNotContains(2, 'foo'); // @phpstan-ignore-line
     }
 
     /**
      * Asserts the method iClickOnText throws an exception if element not found.
-     *
-     * @expectedException \Behat\Mink\Exception\ElementNotFoundException
-     * @expectedExceptionMessage Text matching xpath "foo" not found.
      */
     public function testIClickOnTextThrowsExceptionIfElementNotFound(): void
     {
+        $this->expectException(ElementNotFoundException::class);
+        $this->expectExceptionMessage('Text matching xpath "foo" not found');
+
         $page = $this->createMock(DocumentElement::class);
         $page->expects($this->once())->method('find')->with($this->equalTo('xpath'), $this->equalTo("//*[contains(.,'foo')]"));
 
@@ -265,11 +262,10 @@ class ExtraSessionTraitTest extends TestCase
         $session->expects($this->once())->method('getPage')->willReturn($page);
         $session->expects($this->once())->method('getDriver')->willReturn($this->createMock(DriverInterface::class));
 
-        /** @var ExtraSessionTrait|MockObject $mock */
-        $mock = $this->getExtraSessionMock();
-        $mock->expects($this->exactly(2))->method('getSession')->willReturn($session);
+        $trait = $this->getExtraSessionMock();
+        $trait->expects($this->exactly(2))->method('getSession')->willReturn($session);
 
-        $mock->iClickOnText('foo');
+        $trait->iClickOnText('foo'); // @phpstan-ignore-line
     }
 
     /**
@@ -286,11 +282,10 @@ class ExtraSessionTraitTest extends TestCase
         $session = $this->createMock(Session::class);
         $session->expects($this->once())->method('getPage')->willReturn($page);
 
-        /** @var ExtraSessionTrait|MockObject $mock */
-        $mock = $this->getExtraSessionMock();
-        $mock->expects($this->once())->method('getSession')->willReturn($session);
+        $trait = $this->getExtraSessionMock();
+        $trait->expects($this->once())->method('getSession')->willReturn($session);
 
-        $mock->iClickOnText('foo');
+        $trait->iClickOnText('foo'); // @phpstan-ignore-line
     }
 
     /**

--- a/tests/ExtraWebAssertTraitTest.php
+++ b/tests/ExtraWebAssertTraitTest.php
@@ -36,12 +36,11 @@ class ExtraWebAssertTraitTest extends TestCase
         $webAssert = $this->createMock(WebAssert::class);
         $webAssert->expects($this->once())->method('elementAttributeExists')->with($this->equalTo('css'), $this->equalTo('a.action_bar__next'));
 
-        /** @var ExtraWebAssertTrait|MockObject $mock */
-        $mock = $this->getExtraWebAssertMock();
-        $mock->expects($this->once())->method('assertSession')->willReturn($webAssert);
-        $mock->expects($this->once())->method('fixStepArgument')->with($this->equalTo('disabled'));
+        $trait = $this->getExtraWebAssertMock();
+        $trait->expects($this->once())->method('assertSession')->willReturn($webAssert);
+        $trait->expects($this->once())->method('fixStepArgument')->with($this->equalTo('disabled'));
 
-        $mock->assertElementAttributeExists('a.action_bar__next', 'disabled');
+        $trait->assertElementAttributeExists('a.action_bar__next', 'disabled'); // @phpstan-ignore-line
     }
 
     /**
@@ -56,13 +55,12 @@ class ExtraWebAssertTraitTest extends TestCase
         $session->expects($this->once())->method('getPage')->willReturn($page);
         $session->expects($this->once())->method('getDriver')->willReturn($this->createMock(DriverInterface::class));
 
-        /** @var ExtraWebAssertTrait|MockObject $mock */
-        $mock = $this->getExtraWebAssertMock();
-        $mock->expects($this->exactly(2))->method('getSession')->willReturn($session);
+        $trait = $this->getExtraWebAssertMock();
+        $trait->expects($this->exactly(2))->method('getSession')->willReturn($session);
 
         $this->expectException(ElementNotFoundException::class);
 
-        $mock->clickElement('.sonata-ba-list a.sonata-link-identifier');
+        $trait->clickElement('.sonata-ba-list a.sonata-link-identifier'); // @phpstan-ignore-line
     }
 
     /**
@@ -79,11 +77,10 @@ class ExtraWebAssertTraitTest extends TestCase
         $session = $this->createMock(Session::class);
         $session->expects($this->once())->method('getPage')->willReturn($page);
 
-        /** @var ExtraWebAssertTrait|MockObject $mock */
-        $mock = $this->getExtraWebAssertMock();
-        $mock->expects($this->once())->method('getSession')->willReturn($session);
+        $trait = $this->getExtraWebAssertMock();
+        $trait->expects($this->once())->method('getSession')->willReturn($session);
 
-        $mock->clickElement('.sonata-ba-list a.sonata-link-identifier');
+        $trait->clickElement('.sonata-ba-list a.sonata-link-identifier'); // @phpstan-ignore-line
     }
 
     /**
@@ -99,11 +96,10 @@ class ExtraWebAssertTraitTest extends TestCase
         $session = $this->createMock(Session::class);
         $session->expects($this->once())->method('getPage')->willReturn($page);
 
-        /** @var ExtraWebAssertTrait|MockObject $mock */
-        $mock = $this->getExtraWebAssertMock();
-        $mock->expects($this->once())->method('getSession')->willReturn($session);
+        $trait = $this->getExtraWebAssertMock();
+        $trait->expects($this->once())->method('getSession')->willReturn($session);
 
-        $mock->assertAtLeastNumElements(2, '.foo');
+        $trait->assertAtLeastNumElements(2, '.foo'); // @phpstan-ignore-line
     }
 
     /**
@@ -119,11 +115,10 @@ class ExtraWebAssertTraitTest extends TestCase
         $session = $this->createMock(Session::class);
         $session->expects($this->once())->method('getPage')->willReturn($page);
 
-        /** @var ExtraWebAssertTrait|MockObject $mock */
-        $mock = $this->getExtraWebAssertMock();
-        $mock->expects($this->once())->method('getSession')->willReturn($session);
+        $trait = $this->getExtraWebAssertMock();
+        $trait->expects($this->once())->method('getSession')->willReturn($session);
 
-        $mock->assertAtLeastNumElements(2, '.foo');
+        $trait->assertAtLeastNumElements(2, '.foo'); // @phpstan-ignore-line
     }
 
     /**
@@ -139,14 +134,13 @@ class ExtraWebAssertTraitTest extends TestCase
         $session = $this->createMock(Session::class);
         $session->expects($this->once())->method('getPage')->willReturn($page);
 
-        /** @var ExtraWebAssertTrait|MockObject $mock */
-        $mock = $this->getExtraWebAssertMock();
-        $mock->expects($this->once())->method('getSession')->willReturn($session);
+        $trait = $this->getExtraWebAssertMock();
+        $trait->expects($this->once())->method('getSession')->willReturn($session);
 
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage("1 \".foo\" found on the page, but should at least 2.");
 
-        $mock->assertAtLeastNumElements(2, '.foo');
+        $trait->assertAtLeastNumElements(2, '.foo'); // @phpstan-ignore-line
     }
 
     /**
@@ -161,14 +155,13 @@ class ExtraWebAssertTraitTest extends TestCase
         $session->expects($this->once())->method('getPage')->willReturn($page);
         $session->expects($this->once())->method('getDriver')->willReturn($this->createMock(DriverInterface::class));
 
-        /** @var ExtraWebAssertTrait|MockObject $mock */
-        $mock = $this->getExtraWebAssertMock();
-        $mock->expects($this->exactly(2))->method('getSession')->willReturn($session);
+        $trait = $this->getExtraWebAssertMock();
+        $trait->expects($this->exactly(2))->method('getSession')->willReturn($session);
 
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage("Element matching css \".foo\" not found.");
 
-        $mock->assertAtLeastNumElements(2, '.foo');
+        $trait->assertAtLeastNumElements(2, '.foo'); // @phpstan-ignore-line
     }
 
     /**
@@ -184,11 +177,10 @@ class ExtraWebAssertTraitTest extends TestCase
         $session = $this->createMock(Session::class);
         $session->expects($this->once())->method('getPage')->willReturn($page);
 
-        /** @var ExtraWebAssertTrait|MockObject $mock */
-        $mock = $this->getExtraWebAssertMock();
-        $mock->expects($this->once())->method('getSession')->willReturn($session);
+        $trait = $this->getExtraWebAssertMock();
+        $trait->expects($this->once())->method('getSession')->willReturn($session);
 
-        $mock->assertExactlyNumElement(2, '.foo');
+        $trait->assertExactlyNumElement(2, '.foo'); // @phpstan-ignore-line
     }
 
     /**
@@ -204,14 +196,13 @@ class ExtraWebAssertTraitTest extends TestCase
         $session = $this->createMock(Session::class);
         $session->expects($this->once())->method('getPage')->willReturn($page);
 
-        /** @var ExtraWebAssertTrait|MockObject $mock */
-        $mock = $this->getExtraWebAssertMock();
-        $mock->expects($this->once())->method('getSession')->willReturn($session);
+        $trait = $this->getExtraWebAssertMock();
+        $trait->expects($this->once())->method('getSession')->willReturn($session);
 
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage("1 \".foo\" found on the page, but should find 2.");
 
-        $mock->assertExactlyNumElement(2, '.foo');
+        $trait->assertExactlyNumElement(2, '.foo'); // @phpstan-ignore-line
     }
 
     /**
@@ -227,14 +218,13 @@ class ExtraWebAssertTraitTest extends TestCase
         $session = $this->createMock(Session::class);
         $session->expects($this->once())->method('getPage')->willReturn($page);
 
-        /** @var ExtraWebAssertTrait|MockObject $mock */
-        $mock = $this->getExtraWebAssertMock();
-        $mock->expects($this->once())->method('getSession')->willReturn($session);
+        $trait = $this->getExtraWebAssertMock();
+        $trait->expects($this->once())->method('getSession')->willReturn($session);
 
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage("3 \".foo\" found on the page, but should find 2.");
 
-        $mock->assertExactlyNumElement(2, '.foo');
+        $trait->assertExactlyNumElement(2, '.foo'); // @phpstan-ignore-line
     }
 
     /**
@@ -249,14 +239,13 @@ class ExtraWebAssertTraitTest extends TestCase
         $session->expects($this->once())->method('getPage')->willReturn($page);
         $session->expects($this->once())->method('getDriver')->willReturn($this->createMock(DriverInterface::class));
 
-        /** @var ExtraWebAssertTrait|MockObject $mock */
-        $mock = $this->getExtraWebAssertMock();
-        $mock->expects($this->exactly(2))->method('getSession')->willReturn($session);
+        $trait = $this->getExtraWebAssertMock();
+        $trait->expects($this->exactly(2))->method('getSession')->willReturn($session);
 
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage("Element matching css \".foo\" not found.");
 
-        $mock->assertExactlyNumElement(2, '.foo');
+        $trait->assertExactlyNumElement(2, '.foo'); // @phpstan-ignore-line
     }
 
     /**
@@ -267,11 +256,10 @@ class ExtraWebAssertTraitTest extends TestCase
         $webAssert = $this->createMock(WebAssert::class);
         $webAssert->expects($this->once())->method('elementAttributeNotContains')->with($this->equalTo('css'), $this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo('value'));
 
-        /** @var ExtraWebAssertTrait|MockObject $mock */
-        $mock = $this->getExtraWebAssertMock();
-        $mock->expects($this->once())->method('assertSession')->willReturn($webAssert);
+        $trait = $this->getExtraWebAssertMock();
+        $trait->expects($this->once())->method('assertSession')->willReturn($webAssert);
 
-        $mock->elementAttributeNotContains('foo', 'bar', 'value');
+        $trait->elementAttributeNotContains('foo', 'bar', 'value'); // @phpstan-ignore-line
     }
 
     /**

--- a/tests/ReloadCookiesTraitTest.php
+++ b/tests/ReloadCookiesTraitTest.php
@@ -34,20 +34,20 @@ class ReloadCookiesTraitTest extends TestCase
     /**
      * Test the doOnce method.
      *
-     * @param array $tags
-     * @param array $expectedCookies
-     * @param array $cookies
-     * @param array $expectedSteps
-     * @param array $steps
-     * @param int   $resetCounter
-     * @param int   $sessionCounter
-     * @param int   $driverCounter
+     * @param array<mixed> $tags
+     * @param array<mixed> $expectedCookies
+     * @param array<mixed> $cookies
+     * @param array<mixed> $expectedSteps
+     * @param array<mixed> $steps
+     * @param int          $resetCounter
+     * @param int          $sessionCounter
+     * @param int          $driverCounter
      *
      * @dataProvider doOnceProvider
      *
      * @throws \ReflectionException
      */
-    public function testDoOnce(array $tags, array $expectedCookies, array $cookies, array $expectedSteps, array $steps, int $resetCounter, int $sessionCounter, int $driverCounter)
+    public function testDoOnce(array $tags, array $expectedCookies, array $cookies, array $expectedSteps, array $steps, int $resetCounter, int $sessionCounter, int $driverCounter): void
     {
         $wdSession = $this->createMock(SessionMockInterface::class);
         $wdSession->expects($this->exactly($resetCounter))->method('deleteAllCookies');
@@ -74,7 +74,7 @@ class ReloadCookiesTraitTest extends TestCase
     }
 
     /**
-     * @return \Generator
+     * @return \Generator<mixed>
      */
     public function doOnceProvider(): \Generator
     {
@@ -223,12 +223,12 @@ class ReloadCookiesTraitTest extends TestCase
 
     /**
      * Tests the assertDriverSupported method.
-     *
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Saving cookies only works with driver Behat\Mink\Driver\Selenium2Driver
      */
     public function testAssertDriverSupportedWithException(): void
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Saving cookies only works with driver Behat\Mink\Driver\Selenium2Driver');
+
         $driver = $this->createMock(CoreDriver::class);
 
         $session = $this->createMock(Session::class);

--- a/tests/SonataAdminTraitTest.php
+++ b/tests/SonataAdminTraitTest.php
@@ -34,16 +34,16 @@ class SonataAdminTraitTest extends TestCase
      */
     public function testLogin(): void
     {
-        /** @var SonataAdminTrait|MockObject $mock */
-        $mock = $this->getSonataAdminMock();
-        $mock->expects($this->once())->method('visitPath')->with($this->equalTo('sonata_user_admin_security_login'));
-        $mock->expects($this->exactly(2))->method('fillField')->withConsecutive(
+        $trait = $this->getSonataAdminMock();
+
+        $trait->expects($this->once())->method('visitPath')->with($this->equalTo('sonata_user_admin_security_login'));
+        $trait->expects($this->exactly(2))->method('fillField')->withConsecutive(
             [$this->equalTo('_username'), $this->equalTo('login')],
             [$this->equalTo('_password'), $this->equalTo('password')]
         );
-        $mock->expects($this->once())->method('pressButton')->with($this->equalTo('Connexion'));
+        $trait->expects($this->once())->method('pressButton')->with($this->equalTo('Connexion'));
 
-        $mock->login('login', 'password');
+        $trait->login('login', 'password'); // @phpstan-ignore-line
     }
 
     /**
@@ -51,8 +51,8 @@ class SonataAdminTraitTest extends TestCase
      */
     public function testIOpenMenuItemByText(): void
     {
-        /** @var SonataAdminTrait|MockObject $mock */
-        $mock    = $this->getSonataAdminMock();
+        $trait = $this->getSonataAdminMock();
+
         $session = $this->createMock(Session::class);
         $page    = $this->createMock(DocumentElement::class);
         $element = $this->createMock(NodeElement::class);
@@ -60,9 +60,9 @@ class SonataAdminTraitTest extends TestCase
         $element->expects($this->once())->method('click');
         $page->expects($this->once())->method('find')->with('xpath', '//aside//span[text()="foo"]')->willReturn($element);
         $session->expects($this->once())->method('getPage')->willReturn($page);
-        $mock->expects($this->once())->method('getSession')->willReturn($session);
+        $trait->expects($this->once())->method('getSession')->willReturn($session);
 
-        $mock->iOpenMenuItemByText('foo');
+        $trait->iOpenMenuItemByText('foo'); // @phpstan-ignore-line
     }
 
     /**
@@ -70,8 +70,8 @@ class SonataAdminTraitTest extends TestCase
      */
     public function testIOpenMenuItemByTextWithElementNotFound(): void
     {
-        /** @var SonataAdminTrait|MockObject $mock */
-        $mock    = $this->getSonataAdminMock();
+        $trait = $this->getSonataAdminMock();
+
         $session = $this->createMock(Session::class);
         $page    = $this->createMock(DocumentElement::class);
         $driver  = $this->createMock(DriverInterface::class);
@@ -79,12 +79,12 @@ class SonataAdminTraitTest extends TestCase
         $page->expects($this->once())->method('find')->with('xpath', '//aside//span[text()="foo"]');
         $session->expects($this->once())->method('getPage')->willReturn($page);
         $session->expects($this->once())->method('getDriver')->willReturn($driver);
-        $mock->expects($this->exactly(2))->method('getSession')->willReturn($session);
+        $trait->expects($this->exactly(2))->method('getSession')->willReturn($session);
 
         $this->expectException(ElementNotFoundException::class);
         $this->expectExceptionMessage("Tag with text \"foo\" not found");
 
-        $mock->iOpenMenuItemByText('foo');
+        $trait->iOpenMenuItemByText('foo'); // @phpstan-ignore-line
     }
 
     /**
@@ -92,8 +92,8 @@ class SonataAdminTraitTest extends TestCase
      */
     public function testIShouldSeeActionInNavbarWithoutElementFound(): void
     {
-        /** @var SonataAdminTrait|MockObject $mock */
-        $mock    = $this->getSonataAdminMock();
+        $trait = $this->getSonataAdminMock();
+
         $driver  = $this->createMock(DriverInterface::class);
         $session = $this->createMock(Session::class);
         $page    = $this->createMock(DocumentElement::class);
@@ -101,12 +101,12 @@ class SonataAdminTraitTest extends TestCase
         $page->expects($this->once())->method('find')->with($this->equalTo('xpath'), $this->equalTo('//nav//a[contains(.,"foo")]'));
         $session->expects($this->once())->method('getDriver')->willReturn($driver);
         $session->expects($this->once())->method('getPage')->willReturn($page);
-        $mock->expects($this->exactly(2))->method('getSession')->willReturn($session);
+        $trait->expects($this->exactly(2))->method('getSession')->willReturn($session);
 
         $this->expectException(ElementNotFoundException::class);
         $this->expectExceptionMessage("Tag with text \"foo\" not found");
 
-        $mock->iShouldSeeActionInNavbar('foo');
+        $trait->iShouldSeeActionInNavbar('foo'); // @phpstan-ignore-line
     }
 
     /**
@@ -114,8 +114,8 @@ class SonataAdminTraitTest extends TestCase
      */
     public function testIShouldSeeActionInNavbarWithoutElementNotVisible(): void
     {
-        /** @var SonataAdminTrait|MockObject $mock */
-        $mock    = $this->getSonataAdminMock();
+        $trait = $this->getSonataAdminMock();
+
         $session = $this->createMock(Session::class);
         $page    = $this->createMock(DocumentElement::class);
         $element = $this->createMock(NodeElement::class);
@@ -123,12 +123,12 @@ class SonataAdminTraitTest extends TestCase
         $element->expects($this->once())->method('isVisible')->willReturn(false);
         $page->expects($this->once())->method('find')->with($this->equalTo('xpath'), $this->equalTo('//nav//a[contains(.,"foo")]'))->willReturn($element);
         $session->expects($this->once())->method('getPage')->willReturn($page);
-        $mock->expects($this->once())->method('getSession')->willReturn($session);
+        $trait->expects($this->once())->method('getSession')->willReturn($session);
 
         $this->expectException(ElementNotVisible::class);
         $this->expectExceptionMessage("Cannot find action \"foo\" in Navbar action");
 
-        $mock->iShouldSeeActionInNavbar('foo');
+        $trait->iShouldSeeActionInNavbar('foo'); // @phpstan-ignore-line
     }
 
     /**
@@ -136,8 +136,8 @@ class SonataAdminTraitTest extends TestCase
      */
     public function testIShouldNotSeeActionInNavbarWithElement(): void
     {
-        /** @var SonataAdminTrait|MockObject $mock */
-        $mock    = $this->getSonataAdminMock();
+        $trait = $this->getSonataAdminMock();
+
         $driver  = $this->createMock(DriverInterface::class);
         $session = $this->createMock(Session::class);
         $page    = $this->createMock(DocumentElement::class);
@@ -146,12 +146,12 @@ class SonataAdminTraitTest extends TestCase
         $page->expects($this->once())->method('find')->with($this->equalTo('xpath'), $this->equalTo('//nav//a[contains(.,"foo")]'))->willReturn($element);
         $session->expects($this->once())->method('getDriver')->willReturn($driver);
         $session->expects($this->once())->method('getPage')->willReturn($page);
-        $mock->expects($this->exactly(2))->method('getSession')->willReturn($session);
+        $trait->expects($this->exactly(2))->method('getSession')->willReturn($session);
 
         $this->expectException(ElementHtmlException::class);
         $this->expectExceptionMessage("Action \"foo\" has been found in Navbar action");
 
-        $mock->iShouldNotSeeActionInNavbar('foo');
+        $trait->iShouldNotSeeActionInNavbar('foo'); // @phpstan-ignore-line
     }
 
     /**
@@ -159,8 +159,8 @@ class SonataAdminTraitTest extends TestCase
      */
     public function testIClickOnActionInNavbarWithoutElementFound(): void
     {
-        /** @var SonataAdminTrait|MockObject $mock */
-        $mock    = $this->getSonataAdminMock();
+        $trait = $this->getSonataAdminMock();
+
         $driver  = $this->createMock(DriverInterface::class);
         $session = $this->createMock(Session::class);
         $page    = $this->createMock(DocumentElement::class);
@@ -168,12 +168,12 @@ class SonataAdminTraitTest extends TestCase
         $page->expects($this->once())->method('find')->with($this->equalTo('xpath'), $this->equalTo('//nav//a[contains(.,"foo")]'));
         $session->expects($this->once())->method('getDriver')->willReturn($driver);
         $session->expects($this->once())->method('getPage')->willReturn($page);
-        $mock->expects($this->exactly(2))->method('getSession')->willReturn($session);
+        $trait->expects($this->exactly(2))->method('getSession')->willReturn($session);
 
         $this->expectException(ElementNotFoundException::class);
         $this->expectExceptionMessage("Tag with text \"foo\" not found");
 
-        $mock->iClickOnActionInNavbar('foo');
+        $trait->iClickOnActionInNavbar('foo'); // @phpstan-ignore-line
     }
 
     /**
@@ -181,8 +181,8 @@ class SonataAdminTraitTest extends TestCase
      */
     public function testIClickOnActionInNavbarWithElementFound(): void
     {
-        /** @var SonataAdminTrait|MockObject $mock */
-        $mock    = $this->getSonataAdminMock();
+        $trait = $this->getSonataAdminMock();
+
         $session = $this->createMock(Session::class);
         $page    = $this->createMock(DocumentElement::class);
         $element = $this->createMock(NodeElement::class);
@@ -190,9 +190,9 @@ class SonataAdminTraitTest extends TestCase
         $element->expects($this->once())->method('click');
         $page->expects($this->once())->method('find')->with($this->equalTo('xpath'), $this->equalTo('//nav//a[contains(.,"foo")]'))->willReturn($element);
         $session->expects($this->once())->method('getPage')->willReturn($page);
-        $mock->expects($this->once())->method('getSession')->willReturn($session);
+        $trait->expects($this->once())->method('getSession')->willReturn($session);
 
-        $mock->iClickOnActionInNavbar('foo');
+        $trait->iClickOnActionInNavbar('foo'); // @phpstan-ignore-line
     }
 
     /**
@@ -200,13 +200,12 @@ class SonataAdminTraitTest extends TestCase
      */
     public function testClickingOnElementShouldOpenPopinWithoutExtraSessionTraitUse(): void
     {
-        /** @var SonataAdminTrait|MockObject $mock */
-        $mock = $this->getSonataAdminMock();
+        $trait = $this->getSonataAdminMock();
 
         $this->expectExceptionMessage("Please use the trait Ekino\BehatHelpers\ExtraSessionTrait in the class Trait_SonataAdminTrait");
         $this->expectException(\RuntimeException::class);
 
-        $mock->clickingOnElementShouldOpenPopin('foo', 'bar');
+        $trait->clickingOnElementShouldOpenPopin('foo', 'bar'); // @phpstan-ignore-line
     }
 
     /**
@@ -214,13 +213,12 @@ class SonataAdminTraitTest extends TestCase
      */
     public function testThePopinShouldBeClosedWithoutExtraSessionTraitUse(): void
     {
-        /** @var SonataAdminTrait|MockObject $mock */
-        $mock = $this->getSonataAdminMock();
+        $trait = $this->getSonataAdminMock();
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage("Please use the trait Ekino\BehatHelpers\ExtraSessionTrait in the class Trait_SonataAdminTrait");
 
-        $mock->clickingOnElementShouldOpenPopin('foo', 'bar');
+        $trait->clickingOnElementShouldOpenPopin('foo', 'bar'); // @phpstan-ignore-line
     }
 
     /**
@@ -228,8 +226,8 @@ class SonataAdminTraitTest extends TestCase
      */
     public function testThePopinShouldNotBeOpenedWithOpenedPopin(): void
     {
-        /** @var SonataAdminTrait|MockObject $mock */
-        $mock    = $this->getSonataAdminMock();
+        $trait = $this->getSonataAdminMock();
+
         $driver  = $this->createMock(DriverInterface::class);
         $session = $this->createMock(Session::class);
         $page    = $this->createMock(DocumentElement::class);
@@ -239,12 +237,12 @@ class SonataAdminTraitTest extends TestCase
         $page->expects($this->once())->method('find')->with($this->equalTo('css'), $this->equalTo('div.modal[id$=foo]'))->willReturn($element);
         $session->expects($this->once())->method('getPage')->willReturn($page);
         $session->expects($this->once())->method('getDriver')->willReturn($driver);
-        $mock->expects($this->exactly(2))->method('getSession')->willReturn($session);
+        $trait->expects($this->exactly(2))->method('getSession')->willReturn($session);
 
         $this->expectExceptionMessage("Popin div.modal[id$=foo] was found and opened");
         $this->expectException(ElementHtmlException::class);
 
-        $mock->thePopinShouldNotBeOpened('foo');
+        $trait->thePopinShouldNotBeOpened('foo'); // @phpstan-ignore-line
     }
 
     /**
@@ -252,16 +250,16 @@ class SonataAdminTraitTest extends TestCase
      */
     public function testThePopinShouldNotBeOpenedWithoutPopin(): void
     {
-        /** @var SonataAdminTrait|MockObject $mock */
-        $mock    = $this->getSonataAdminMock();
+        $trait = $this->getSonataAdminMock();
+
         $session = $this->createMock(Session::class);
         $page    = $this->createMock(DocumentElement::class);
 
         $page->expects($this->once())->method('find')->with($this->equalTo('css'), $this->equalTo('div.modal[id$=foo]'))->willReturn(null);
         $session->expects($this->once())->method('getPage')->willReturn($page);
-        $mock->expects($this->once())->method('getSession')->willReturn($session);
+        $trait->expects($this->once())->method('getSession')->willReturn($session);
 
-        $mock->thePopinShouldNotBeOpened('foo');
+        $trait->thePopinShouldNotBeOpened('foo'); // @phpstan-ignore-line
     }
 
     /**
@@ -269,8 +267,8 @@ class SonataAdminTraitTest extends TestCase
      */
     public function testThePopinShouldBeOpened(): void
     {
-        /** @var SonataAdminTrait|MockObject $mock */
-        $mock    = $this->getSonataAdminMock();
+        $trait = $this->getSonataAdminMock();
+
         $session = $this->createMock(Session::class);
         $page    = $this->createMock(DocumentElement::class);
         $element = $this->createMock(NodeElement::class);
@@ -278,9 +276,9 @@ class SonataAdminTraitTest extends TestCase
         $element->expects($this->once())->method('isVisible')->willReturn(true);
         $page->expects($this->once())->method('find')->with($this->equalTo('css'), $this->equalTo('div.modal[id$=foo]'))->willReturn($element);
         $session->expects($this->once())->method('getPage')->willReturn($page);
-        $mock->expects($this->once())->method('getSession')->willReturn($session);
+        $trait->expects($this->once())->method('getSession')->willReturn($session);
 
-        $mock->thePopinShouldBeOpened('foo');
+        $trait->thePopinShouldBeOpened('foo'); // @phpstan-ignore-line
     }
 
     /**
@@ -288,8 +286,8 @@ class SonataAdminTraitTest extends TestCase
      */
     public function testThePopinShouldBeOpenedWithInvisiblePopin(): void
     {
-        /** @var SonataAdminTrait|MockObject $mock */
-        $mock    = $this->getSonataAdminMock();
+        $trait = $this->getSonataAdminMock();
+
         $session = $this->createMock(Session::class);
         $page    = $this->createMock(DocumentElement::class);
         $element = $this->createMock(NodeElement::class);
@@ -297,12 +295,12 @@ class SonataAdminTraitTest extends TestCase
         $element->expects($this->once())->method('isVisible')->willReturn(false);
         $page->expects($this->once())->method('find')->with($this->equalTo('css'), $this->equalTo('div.modal[id$=foo]'))->willReturn($element);
         $session->expects($this->once())->method('getPage')->willReturn($page);
-        $mock->expects($this->once())->method('getSession')->willReturn($session);
+        $trait->expects($this->once())->method('getSession')->willReturn($session);
 
         $this->expectExceptionMessage("Modal div.modal[id$=foo] should be opened and visible");
         $this->expectException(ElementNotVisible::class);
 
-        $mock->thePopinShouldBeOpened('foo');
+        $trait->thePopinShouldBeOpened('foo'); // @phpstan-ignore-line
     }
 
     /**
@@ -310,19 +308,19 @@ class SonataAdminTraitTest extends TestCase
      */
     public function testThePopinShouldBeOpenedWithoutPopin(): void
     {
-        /** @var SonataAdminTrait|MockObject $mock */
-        $mock    = $this->getSonataAdminMock();
+        $trait = $this->getSonataAdminMock();
+
         $session = $this->createMock(Session::class);
         $page    = $this->createMock(DocumentElement::class);
 
         $page->expects($this->once())->method('find')->with($this->equalTo('css'), $this->equalTo('div.modal[id$=foo]'))->willReturn(null);
         $session->expects($this->once())->method('getPage')->willReturn($page);
-        $mock->expects($this->once())->method('getSession')->willReturn($session);
+        $trait->expects($this->once())->method('getSession')->willReturn($session);
 
         $this->expectExceptionMessage("Modal div.modal[id$=foo] should be opened and visible");
         $this->expectException(ElementNotVisible::class);
 
-        $mock->thePopinShouldBeOpened('foo');
+        $trait->thePopinShouldBeOpened('foo'); // @phpstan-ignore-line
     }
 
     /**
@@ -330,8 +328,8 @@ class SonataAdminTraitTest extends TestCase
      */
     public function testIFillInSelect2Field(): void
     {
-        /** @var SonataAdminTrait|MockObject $mock */
-        $mock    = $this->getSonataAdminMock();
+        $trait = $this->getSonataAdminMock();
+
         $session = $this->createMock(Session::class);
         $page    = $this->createMock(DocumentElement::class);
         $element = $this->createMock(NodeElement::class);
@@ -340,9 +338,9 @@ class SonataAdminTraitTest extends TestCase
         $page->expects($this->once())->method('find')->with($this->equalTo('xpath'), $this->equalTo(sprintf('//select[@id="%s"]//option[text()="%s"]', 'bar', 'foo')))->willReturn($element);
         $session->expects($this->once())->method('getPage')->willReturn($page);
         $session->expects($this->once())->method('executeScript')->with("jQuery('#bar').val([\"foo\"]).trigger('change');");
-        $mock->expects($this->exactly(2))->method('getSession')->willReturn($session);
+        $trait->expects($this->exactly(2))->method('getSession')->willReturn($session);
 
-        $mock->iFillInSelect2Field('bar', 'foo');
+        $trait->iFillInSelect2Field('bar', 'foo'); // @phpstan-ignore-line
     }
 
     /**

--- a/tests/SonataPageAdminTraitTest.php
+++ b/tests/SonataPageAdminTraitTest.php
@@ -96,7 +96,6 @@ class SonataPageAdminTraitTest extends TestCase
      */
     public function testIOpenTheContainerByText(): void
     {
-        /** @var SonataPageAdminTrait|MockObject $trait */
         $trait = $this->getSonataPageAdminTraitMock();
 
         $this->element->expects($this->once())->method('click');
@@ -109,7 +108,7 @@ class SonataPageAdminTraitTest extends TestCase
         $this->session->expects($this->once())->method('getPage')->willReturn($this->page);
         $trait->expects($this->once())->method('getSession')->willReturn($this->session);
 
-        $trait->iOpenTheContainerByText("Content");
+        $trait->iOpenTheContainerByText("Content"); // @phpstan-ignore-line
     }
 
     /**
@@ -117,7 +116,6 @@ class SonataPageAdminTraitTest extends TestCase
      */
     public function testIOpenTheContainerByTextNotFound(): void
     {
-        /** @var SonataPageAdminTrait|MockObject $trait */
         $trait = $this->getSonataPageAdminTraitMock();
 
         $this->page->expects($this->once())
@@ -131,7 +129,7 @@ class SonataPageAdminTraitTest extends TestCase
         $this->expectExceptionMessage("Tag with text \"Content\" not found.");
         $this->expectException(ElementNotFoundException::class);
 
-        $trait->iOpenTheContainerByText("Content");
+        $trait->iOpenTheContainerByText("Content"); // @phpstan-ignore-line
     }
 
     /**
@@ -139,7 +137,6 @@ class SonataPageAdminTraitTest extends TestCase
      */
     public function testIAddABlockWithTheName(): void
     {
-        /** @var SonataPageAdminTrait|MockObject $trait */
         $trait = $this->getSonataPageAdminTraitMock();
 
         $this->button->expects($this->once())->method('click');
@@ -163,7 +160,7 @@ class SonataPageAdminTraitTest extends TestCase
         $trait->expects($this->exactly(3))->method('iWaitForCssElementBeingVisible');
         $trait->expects($this->exactly(1))->method('clickingOnElementShouldOpenPopin')->with('div.page-composer__block-type-selector button', 'blockSelectModal');
 
-        $trait->iAddABlockWithTheName("Simple text", "Foo");
+        $trait->iAddABlockWithTheName("Simple text", "Foo"); // @phpstan-ignore-line
     }
 
     /**
@@ -171,7 +168,6 @@ class SonataPageAdminTraitTest extends TestCase
      */
     public function testIAddABlockWithTheNameButtonNotFound(): void
     {
-        /** @var SonataPageAdminTrait|MockObject $trait */
         $trait = $this->getSonataPageAdminTraitMock();
 
         $trait->expects($this->at(0))
@@ -192,7 +188,7 @@ class SonataPageAdminTraitTest extends TestCase
         $this->expectExceptionMessage("Tag with block \"Simple text\" not found.");
         $this->expectException(ElementNotFoundException::class);
 
-        $trait->iAddABlockWithTheName("Simple text", "Foo");
+        $trait->iAddABlockWithTheName("Simple text", "Foo"); // @phpstan-ignore-line
     }
 
     /**
@@ -200,7 +196,6 @@ class SonataPageAdminTraitTest extends TestCase
      */
     public function testIAddBlockWithTheNameBlockNotFound(): void
     {
-        /** @var SonataPageAdminTrait|MockObject $trait */
         $trait = $this->getSonataPageAdminTraitMock();
 
         $this->button->expects($this->once())->method('click');
@@ -224,7 +219,7 @@ class SonataPageAdminTraitTest extends TestCase
         $this->expectExceptionMessage("Tag with input \"Simple text\" not found.");
         $this->expectException(ElementNotFoundException::class);
 
-        $trait->iAddABlockWithTheName("Simple text", "Foo");
+        $trait->iAddABlockWithTheName("Simple text", "Foo"); // @phpstan-ignore-line
     }
 
     /**
@@ -232,7 +227,6 @@ class SonataPageAdminTraitTest extends TestCase
      */
     public function testIAddBlockWithTheNameInputNotFound(): void
     {
-        /** @var SonataPageAdminTrait|MockObject $trait */
         $trait = $this->getSonataPageAdminTraitMock();
 
         $this->button->expects($this->once())->method('click');
@@ -256,7 +250,7 @@ class SonataPageAdminTraitTest extends TestCase
         $this->expectExceptionMessage("Tag with input \"Simple text\" not found.");
         $this->expectException(ElementNotFoundException::class);
 
-        $trait->iAddABlockWithTheName("Simple text", "Foo");
+        $trait->iAddABlockWithTheName("Simple text", "Foo"); // @phpstan-ignore-line
     }
 
     /**
@@ -264,7 +258,6 @@ class SonataPageAdminTraitTest extends TestCase
      */
     public function testIGoToTheTabOfTheBlock(): void
     {
-        /** @var SonataPageAdminTrait|MockObject $trait */
         $trait = $this->getSonataPageAdminTraitMock();
 
         $this->tab->expects($this->once())->method('click');
@@ -276,7 +269,7 @@ class SonataPageAdminTraitTest extends TestCase
         $this->session->expects($this->once())->method('getPage')->willReturn($this->page);
         $trait->expects($this->any())->method('getSession')->willReturn($this->session);
 
-        $trait->iGoToTheTabOfTheBlock("English", "Foo");
+        $trait->iGoToTheTabOfTheBlock("English", "Foo"); // @phpstan-ignore-line
     }
 
     /**
@@ -284,7 +277,6 @@ class SonataPageAdminTraitTest extends TestCase
      */
     public function testIGoToTheTabOfTheBlockNotFound(): void
     {
-        /** @var SonataPageAdminTrait|MockObject $trait */
         $trait = $this->getSonataPageAdminTraitMock();
 
         $this->tab->expects($this->never())->method('click');
@@ -299,7 +291,7 @@ class SonataPageAdminTraitTest extends TestCase
         $this->expectExceptionMessage("Tag not found.");
         $this->expectException(ElementNotFoundException::class);
 
-        $trait->iGoToTheTabOfTheBlock("English", "Foo");
+        $trait->iGoToTheTabOfTheBlock("English", "Foo"); // @phpstan-ignore-line
     }
 
     /**
@@ -307,7 +299,6 @@ class SonataPageAdminTraitTest extends TestCase
      */
     public function testIShouldSeeBlocks(): void
     {
-        /** @var SonataPageAdminTrait|MockObject $trait */
         $trait = $this->getSonataPageAdminTraitMock();
 
         $this->page->expects($this->once())->method('find')
@@ -319,7 +310,7 @@ class SonataPageAdminTraitTest extends TestCase
         $this->session->expects($this->once())->method('getPage')->willReturn($this->page);
         $trait->expects($this->once())->method('getSession')->willReturn($this->session);
 
-        $trait->iShouldSeeBlocks(1);
+        $trait->iShouldSeeBlocks(1); // @phpstan-ignore-line
     }
 
     /**
@@ -327,7 +318,6 @@ class SonataPageAdminTraitTest extends TestCase
      */
     public function testIShouldSeeBlocksElementNotFound(): void
     {
-        /** @var SonataPageAdminTrait|MockObject $trait */
         $trait = $this->getSonataPageAdminTraitMock();
 
         $this->page->expects($this->once())->method('find')
@@ -341,7 +331,7 @@ class SonataPageAdminTraitTest extends TestCase
         $this->expectExceptionMessage("Tag not found.");
         $this->expectException(ElementNotFoundException::class);
 
-        $trait->iShouldSeeBlocks(1);
+        $trait->iShouldSeeBlocks(1); // @phpstan-ignore-line
     }
 
     /**
@@ -349,7 +339,6 @@ class SonataPageAdminTraitTest extends TestCase
      */
     public function testIOpenTheBlock(): void
     {
-        /** @var SonataPageAdminTrait|MockObject $trait */
         $trait = $this->getSonataPageAdminTraitMock();
 
         $trait->expects($this->once())
@@ -365,7 +354,7 @@ class SonataPageAdminTraitTest extends TestCase
         $this->session->expects($this->once())->method('getPage')->willReturn($this->page);
         $trait->expects($this->once())->method('getSession')->willReturn($this->session);
 
-        $trait->iOpenTheBlock("Foo");
+        $trait->iOpenTheBlock("Foo"); // @phpstan-ignore-line
     }
 
     /**
@@ -373,7 +362,6 @@ class SonataPageAdminTraitTest extends TestCase
      */
     public function testIOpenTheBlockNotFound(): void
     {
-        /** @var SonataPageAdminTrait|MockObject $trait */
         $trait = $this->getSonataPageAdminTraitMock();
 
         $this->page->expects($this->once())->method('find')
@@ -387,7 +375,7 @@ class SonataPageAdminTraitTest extends TestCase
         $this->expectExceptionMessage("Tag not found.");
         $this->expectException(ElementNotFoundException::class);
 
-        $trait->iOpenTheBlock("Foo");
+        $trait->iOpenTheBlock("Foo"); // @phpstan-ignore-line
     }
 
     /**
@@ -395,7 +383,6 @@ class SonataPageAdminTraitTest extends TestCase
      */
     public function testISubmitTheBlock(): void
     {
-        /** @var SonataPageAdminTrait|MockObject $trait */
         $trait = $this->getSonataPageAdminTraitMock();
 
         $this->block->expects($this->once())->method('press');
@@ -407,7 +394,7 @@ class SonataPageAdminTraitTest extends TestCase
         $this->session->expects($this->once())->method('getPage')->willReturn($this->page);
         $trait->expects($this->once())->method('getSession')->willReturn($this->session);
 
-        $trait->iSubmitTheBlock("Foo");
+        $trait->iSubmitTheBlock("Foo"); // @phpstan-ignore-line
     }
 
     /**
@@ -415,7 +402,6 @@ class SonataPageAdminTraitTest extends TestCase
      */
     public function testISubmitTheBlockNotFound(): void
     {
-        /** @var SonataPageAdminTrait|MockObject $trait */
         $trait = $this->getSonataPageAdminTraitMock();
 
         $this->page->expects($this->once())->method('find')
@@ -429,7 +415,7 @@ class SonataPageAdminTraitTest extends TestCase
         $this->expectExceptionMessage("Tag not found.");
         $this->expectException(ElementNotFoundException::class);
 
-        $trait->iSubmitTheBlock("Foo");
+        $trait->iSubmitTheBlock("Foo"); // @phpstan-ignore-line
     }
 
     /**
@@ -437,7 +423,6 @@ class SonataPageAdminTraitTest extends TestCase
      */
     public function testIDeleteTheBlock(): void
     {
-        /** @var SonataPageAdminTrait|MockObject $trait */
         $trait = $this->getSonataPageAdminTraitMock();
 
         $this->page->expects($this->at(0))
@@ -469,7 +454,7 @@ class SonataPageAdminTraitTest extends TestCase
         $this->session->expects($this->exactly(4))->method('getPage')->willReturn($this->page);
         $trait->expects($this->exactly(5))->method('getSession')->willReturn($this->session);
 
-        $trait->iDeleteTheBlock("Foo");
+        $trait->iDeleteTheBlock("Foo"); // @phpstan-ignore-line
     }
 
     /**
@@ -477,7 +462,6 @@ class SonataPageAdminTraitTest extends TestCase
      */
     public function testIDeleteTheBlockElementNotFound(): void
     {
-        /** @var SonataPageAdminTrait|MockObject $trait */
         $trait = $this->getSonataPageAdminTraitMock();
 
         $this->page->expects($this->at(0))
@@ -491,7 +475,8 @@ class SonataPageAdminTraitTest extends TestCase
         $this->session->expects($this->once())->method('getDriver')->willReturn($this->driver);
         $this->session->expects($this->once())->method('getPage')->willReturn($this->page);
         $trait->expects($this->exactly(2))->method('getSession')->willReturn($this->session);
-        $trait->iDeleteTheBlock("Foo");
+
+        $trait->iDeleteTheBlock("Foo"); // @phpstan-ignore-line
     }
 
     /**
@@ -499,7 +484,6 @@ class SonataPageAdminTraitTest extends TestCase
      */
     public function testIDeleteTheBlockButtonNotFound(): void
     {
-        /** @var SonataPageAdminTrait|MockObject $trait */
         $trait = $this->getSonataPageAdminTraitMock();
 
         $this->page->expects($this->at(0))
@@ -525,7 +509,7 @@ class SonataPageAdminTraitTest extends TestCase
         $this->session->expects($this->exactly(3))->method('getPage')->willReturn($this->page);
         $trait->expects($this->exactly(4))->method('getSession')->willReturn($this->session);
 
-        $trait->iDeleteTheBlock("Foo");
+        $trait->iDeleteTheBlock("Foo"); // @phpstan-ignore-line
     }
 
     /**
@@ -533,7 +517,6 @@ class SonataPageAdminTraitTest extends TestCase
      */
     public function testIRenameTheBlock(): void
     {
-        /** @var SonataPageAdminTrait|MockObject $trait */
         $trait = $this->getSonataPageAdminTraitMock();
 
         $trait->expects($this->at(0))
@@ -568,7 +551,8 @@ class SonataPageAdminTraitTest extends TestCase
 
         $this->session->expects($this->exactly(4))->method('getPage')->willReturn($this->page);
         $trait->expects($this->exactly(4))->method('getSession')->willReturn($this->session);
-        $trait->iRenameTheBlock("Foo", "Bar");
+
+        $trait->iRenameTheBlock("Foo", "Bar"); // @phpstan-ignore-line
     }
 
     /**
@@ -576,7 +560,6 @@ class SonataPageAdminTraitTest extends TestCase
      */
     public function testIRenameTheBlockInputNotFound(): void
     {
-        /** @var SonataPageAdminTrait|MockObject $trait */
         $trait = $this->getSonataPageAdminTraitMock();
 
         $this->page->expects($this->at(0))
@@ -591,7 +574,7 @@ class SonataPageAdminTraitTest extends TestCase
         $this->expectExceptionMessage("Tag not found.");
         $this->expectException(ElementNotFoundException::class);
 
-        $trait->iRenameTheBlock("Foo", "Bar");
+        $trait->iRenameTheBlock("Foo", "Bar"); // @phpstan-ignore-line
     }
 
     /**
@@ -599,7 +582,6 @@ class SonataPageAdminTraitTest extends TestCase
      */
     public function testTheBlockShouldBeOpened(): void
     {
-        /** @var SonataPageAdminTrait|MockObject $trait */
         $trait = $this->getSonataPageAdminTraitMock();
 
         $this->page->expects($this->once())
@@ -619,7 +601,7 @@ class SonataPageAdminTraitTest extends TestCase
 
         $trait->expects($this->once())->method('assertSession')->willReturn($this->webAssert);
 
-        $trait->theBlockShouldBeOpened("Foo");
+        $trait->theBlockShouldBeOpened("Foo"); // @phpstan-ignore-line
     }
 
     /**
@@ -627,7 +609,6 @@ class SonataPageAdminTraitTest extends TestCase
      */
     public function testTheBlockShouldBeOpenedNotFound(): void
     {
-        /** @var SonataPageAdminTrait|MockObject $trait */
         $trait = $this->getSonataPageAdminTraitMock();
 
         $this->page->expects($this->once())
@@ -642,7 +623,7 @@ class SonataPageAdminTraitTest extends TestCase
         $this->expectExceptionMessage("Tag not found.");
         $this->expectException(ElementNotFoundException::class);
 
-        $trait->theBlockShouldBeOpened("Foo");
+        $trait->theBlockShouldBeOpened("Foo"); // @phpstan-ignore-line
     }
 
     /**
@@ -650,7 +631,6 @@ class SonataPageAdminTraitTest extends TestCase
      */
     public function testTheBlockShouldBeClosed(): void
     {
-        /** @var SonataPageAdminTrait|MockObject $trait */
         $trait = $this->getSonataPageAdminTraitMock();
 
         $trait->expects($this->once())->method('iWaitForCssElementBeingVisible')->with('li.page-composer__container__child:contains(\'Foo\')');
@@ -669,7 +649,7 @@ class SonataPageAdminTraitTest extends TestCase
         $this->session->expects($this->once())->method('getPage')->willReturn($this->page);
         $trait->expects($this->once())->method('getSession')->willReturn($this->session);
 
-        $trait->theBlockShouldBeClosed("Foo");
+        $trait->theBlockShouldBeClosed("Foo"); // @phpstan-ignore-line
     }
 
     /**
@@ -677,7 +657,6 @@ class SonataPageAdminTraitTest extends TestCase
      */
     public function testTheBlockShouldBeClosedNotFound(): void
     {
-        /** @var SonataPageAdminTrait|MockObject $trait */
         $trait = $this->getSonataPageAdminTraitMock();
 
         $trait->expects($this->once())->method('iWaitForCssElementBeingVisible')->with($this->equalTo('li.page-composer__container__child:contains(\'Foo\')'));
@@ -694,7 +673,7 @@ class SonataPageAdminTraitTest extends TestCase
         $this->expectExceptionMessage("Tag not found.");
         $this->expectException(ElementNotFoundException::class);
 
-        $trait->theBlockShouldBeClosed("Foo");
+        $trait->theBlockShouldBeClosed("Foo"); // @phpstan-ignore-line
     }
 
     /**

--- a/tests/Traits/TestHelperTrait.php
+++ b/tests/Traits/TestHelperTrait.php
@@ -23,9 +23,9 @@ trait TestHelperTrait
     /**
      * Call protected/private method of a class.
      *
-     * @param mixed  $object     Instancied object that will return on method on
-     * @param string $methodName Method name to call
-     * @param array  $parameters Array of parameters to pass into method
+     * @param mixed         $object     Instancied object that will return on method on
+     * @param string        $methodName Method name to call
+     * @param array<mixed>  $parameters Array of parameters to pass into method
      *
      * @throws \ReflectionException
      *


### PR DESCRIPTION
## Changelog

* Drop support PHP7.1
* Allow PHP8

## To do

- [x] Update versions of PHP in composer.json
- [x] upgrade version of phpunit /phpunit to 8.5 to be compatible with PHP8
- [x] upgrade version of ekino/phpstan-banned-code to 0.4 to be compatible with PHP8
- [x] upgrade version of phpstan/phpstan to 0.12 to be compatible with ekino/phpstan-banned-code
- [x] update phpstan config
- [x]  update code to be validated by phpstan

## Subject

allow php8 and drop PHP7.1 support
