### PR TITLE
fix(routing): fix regex of RouterAwareTrait

### DIFF
--- a/src/RouterAwareTrait.php
+++ b/src/RouterAwareTrait.php
@@ -46,10 +46,7 @@ trait RouterAwareTrait
             $url = $path;
         }
 
-        // remove host added by router when host is specified in route definition
-        if (preg_match('#^(https?:)?(//)?([^/]+)(.*)$#', $url, $matches)) {
-            $url = $matches[4] ?? $url;
-        }
+        $url = $this->removeHost($url);
 
         $locatedPath = parent::locatePath($url);
 
@@ -57,5 +54,19 @@ trait RouterAwareTrait
         echo $locatedPath;
 
         return $locatedPath;
+    }
+
+    /**
+     * Remove host added by router when host is specified in route definition
+     */
+    private function removeHost(string $url): string
+    {
+        if (preg_match('#^(https?://)?([^/^?]+)(.*)$#', $url, $matches)) {
+            if ($matches[1] !== '') {
+                $url = $matches[3] ?? $url;
+            }
+        }
+
+        return $url;
     }
 }

--- a/tests/RouterAwareTraitTest.php
+++ b/tests/RouterAwareTraitTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the behat/helpers project.
+ *
+ * (c) Ekino
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Ekino\BehatHelpers;
+
+use Ekino\BehatHelpers\RouterAwareTrait;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Tests\Ekino\BehatHelpers\Traits\TestHelperTrait;
+
+class RouterAwareTraitTest extends TestCase
+{
+    use TestHelperTrait;
+
+    /**
+     * Tests the removeHost method.
+     *
+     * @dataProvider getUrls
+     */
+    public function testRemoveHost(string $url, string $result): void
+    {
+        $trait = $this->getRouterAwareTraitMock();
+
+        $this->assertSame($result, $this->invokeMethod($trait, 'removeHost', [$url]));
+    }
+
+    /**
+     * @return \Generator<array<string>>
+     */
+    public function getUrls(): \Generator
+    {
+        yield 'case_1'  => ['http://host.com?foo', '?foo'];
+        yield 'case_2'  => ['http://host.com?foo', '?foo'];
+        yield 'case_3'  => ['http://host.com/foo', '/foo'];
+        yield 'case_4'  => ['https://host.com/foo', '/foo'];
+        yield 'case_5'  => ['http://host.com/foo?bar', '/foo?bar'];
+        yield 'case_6'  => ['https://host.com/foo?bar', '/foo?bar'];
+        yield 'case_7'  => ['http://host.com/foo/bar', '/foo/bar'];
+        yield 'case_8'  => ['https://host.com/foo/bar', '/foo/bar'];
+        yield 'case_9'  => ['http://host.com/foo/bar?baz', '/foo/bar?baz'];
+        yield 'case_10' => ['https://host.com/foo/bar?baz', '/foo/bar?baz'];
+    }
+
+    /**
+     * @return MockObject
+     */
+    private function getRouterAwareTraitMock(): MockObject
+    {
+        return $this->getMockForTrait(
+            RouterAwareTrait::class,
+            [],
+            '',
+            true,
+            true,
+            true,
+            [
+                'locatePath',
+                'removeHost',
+            ]
+        );
+    }
+}


### PR DESCRIPTION
I am targeting the branch master, because it is a fix of the version 0.3.0

The regex that removes the host in the RouterAwareTrait does not manage all cases:
- `http://host/foo/bar` is correctly managed, the returned URL is `/foo/bar` 
-  `/host/foo/bar` is badly managed, the returned URL is `/bar` instead of`/foo/bar` 
-  `http://host?foo` is badly managed, the returned URL is `` instead of`?foo` 

## Changelog
Fix an issue in RouterAwareTrait with some kind of URL

### Fixed
Fix an issue in RouterAwareTrait 
